### PR TITLE
Fixed exception raised in as_credential_descriptors() when testing for valid AuthenticatorTransport enum values.

### DIFF
--- a/src/django_otp_webauthn/models.py
+++ b/src/django_otp_webauthn/models.py
@@ -39,8 +39,11 @@ def as_credential_descriptors(queryset: QuerySet["AbstractWebAuthnCredential"]) 
             # > a PublicKeyCredentialDescriptor for that credential, the
             # > Relying Party SHOULD retrieve that stored value and set it
             # > as the value of the transports member.
-            if t in AuthenticatorTransport:
+            try:
                 transports.append(AuthenticatorTransport(t))
+            except ValueError:
+                pass
+
         descriptors.append(PublicKeyCredentialDescriptor(id=id, transports=transports))
     return descriptors
 


### PR DESCRIPTION
This resolves https://github.com/Stormbase/django-otp-webauthn/issues/5

Prior to python 3.12 trying to use `"foo" in SomeEnum` raises an exception. This was [added in 3.12](https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__).

Since trying to access an enum member using `SomeEnum("a_value")` raises a `ValueError` when that is not a valid value but returns the enum member when it exists, I have updated `models.as_credential_descriptors()` to just directly try to append `AuthenticatorTransport(t)` to the list of transports in a try/except block and pass on a `ValueError`.

With the way the code has been re-organized it looks like the problem code may only get called when registering a passkey on the current main branch rather than when logging in as it does with version 0.1.2 on pypi.

After making this change I can both register a passkey and log in with the created passkey on the main branch code on python 3.11 and 3.12.