### PR TITLE
Add django authentication backend and resolve http 500 error logging in when multiple authentication backends are enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,18 @@ To quickly start using Passkeys in your Django project, follow these steps:
 
    ```
 
-5. Add the registration code to your logged-in user template.
+5. Add `django_otp_webauthn.backends.WebAuthnBackend` to your `AUTHENTICATION_BACKENDS` in your Django settings. This is only required if you are using passkeys for
+passwordless authentication. If another authentication method is required first then this is not necessary.
+
+    ```python
+    AUTHENTICATION_BACKENDS = [
+        ...
+        "django_otp_webauthn.backends.WebAuthnBackend",
+        ...
+    ]
+    ```
+
+6. Add the registration code to your logged-in user template.
 
    ```html
    <!-- logged_in_template.html -->
@@ -131,7 +142,7 @@ To quickly start using Passkeys in your Django project, follow these steps:
    {% render_otp_webauthn_register_scripts %}
    ```
 
-6. On your login page, include the following to enable passwordless login:
+7. On your login page, include the following to enable passwordless login:
 
    ```html
    {% load otp_webauthn %}
@@ -172,13 +183,13 @@ To quickly start using Passkeys in your Django project, follow these steps:
    </form>
    ```
 
-7. Don't forget to run migrations:
+8. Don't forget to run migrations:
 
    ```sh
    python manage.py migrate
    ```
 
-8. That's it! You should now see a "Register Passkey" button on your logged-in user template. Clicking this button will start the registration process. After registration, you should see a "Login using a Passkey" button on your login page. Clicking this button will prompt you to use your Passkey to authenticate. Or if your browser supports it, you will be prompted to use your Passkey when you focus the username field.
+9. That's it! You should now see a "Register Passkey" button on your logged-in user template. Clicking this button will start the registration process. After registration, you should see a "Login using a Passkey" button on your login page. Clicking this button will prompt you to use your Passkey to authenticate. Or if your browser supports it, you will be prompted to use your Passkey when you focus the username field.
 
 ## What exactly is a Passkey?
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ To quickly start using Passkeys in your Django project, follow these steps:
 
    ```
 
-5. Add `django_otp_webauthn.backends.WebAuthnBackend` to your `AUTHENTICATION_BACKENDS` in your Django settings. This is only required if you are using passkeys for
-passwordless authentication. If another authentication method is required first then this is not necessary.
+5. Add `django_otp_webauthn.backends.WebAuthnBackend` to `AUTHENTICATION_BACKENDS` in your Django settings. This step is required to make 'passwordless authentication' work.
+
+If you are exclusively using Passkeys as a secondary verification step, you don't have to add this backend.
 
     ```python
     AUTHENTICATION_BACKENDS = [

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -118,6 +118,11 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "django_otp_webauthn.backends.WebAuthnBackend",
+]
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/

--- a/src/django_otp_webauthn/backends.py
+++ b/src/django_otp_webauthn/backends.py
@@ -8,7 +8,7 @@ from django_otp_webauthn.models import AbstractWebAuthnCredential
 UserModel = get_user_model()
 
 class WebAuthnBackend:
-    """A simple authentication backend used when django_otp_webauthn is used for passwordless authentication"""
+    """A simple authentication backend used when django_otp_webauthn is used for passwordless authentication."""
 
     def authenticate(self, request: HttpRequest, webauthn_credential: AbstractWebAuthnCredential | None = None, **kwargs: Any) -> AbstractBaseUser | None:
         if webauthn_credential:

--- a/src/django_otp_webauthn/backends.py
+++ b/src/django_otp_webauthn/backends.py
@@ -10,9 +10,9 @@ UserModel = get_user_model()
 class WebAuthnBackend:
     """A simple authentication backend used when django_otp_webauthn is used for passwordless authentication"""
 
-    def authenticate(self, request: HttpRequest, web_authn_credential: AbstractWebAuthnCredential | None = None, **kwargs: Any) -> AbstractBaseUser | None:
-        if web_authn_credential:
-            user = web_authn_credential.user
+    def authenticate(self, request: HttpRequest, webauthn_credential: AbstractWebAuthnCredential | None = None, **kwargs: Any) -> AbstractBaseUser | None:
+        if webauthn_credential:
+            user = webauthn_credential.user
             return user if self.user_can_authenticate(user) else None
         return None
     

--- a/src/django_otp_webauthn/backends.py
+++ b/src/django_otp_webauthn/backends.py
@@ -1,0 +1,28 @@
+from typing import Any
+from django.contrib.auth import get_user_model
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.http import HttpRequest
+
+from django_otp_webauthn.models import AbstractWebAuthnCredential
+
+UserModel = get_user_model()
+
+class WebAuthnBackend:
+    """A simple authentication backend used when django_otp_webauthn is used for passwordless authentication"""
+
+    def authenticate(self, request: HttpRequest, web_authn_credential: AbstractWebAuthnCredential | None = None, **kwargs: Any) -> AbstractBaseUser | None:
+        if web_authn_credential:
+            user = web_authn_credential.user
+            return user if self.user_can_authenticate(user) else None
+        return None
+    
+    def get_user(self, user_id) -> AbstractBaseUser | None:
+        user = UserModel._default_manager.get(pk=user_id)
+        return user if self.user_can_authenticate(user) else None
+    
+    def user_can_authenticate(self, user: AbstractBaseUser | None) -> bool:
+        """
+        Reject users with is_active=False. Custom user models that don't have
+        that attribute are allowed.
+        """
+        return bool(user and getattr(user, "is_active", True))

--- a/src/django_otp_webauthn/backends.py
+++ b/src/django_otp_webauthn/backends.py
@@ -17,7 +17,10 @@ class WebAuthnBackend:
         return None
     
     def get_user(self, user_id) -> AbstractBaseUser | None:
-        user = UserModel._default_manager.get(pk=user_id)
+        try:
+            user = UserModel._default_manager.get(pk=user_id)
+        except UserModel.DoesNotExist:
+            return None
         return user if self.user_can_authenticate(user) else None
     
     def user_can_authenticate(self, user: AbstractBaseUser | None) -> bool:

--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 from logging import getLogger
 
 from django.conf import settings
+from django.contrib.auth import authenticate as auth_authenticate
 from django.contrib.auth import get_user_model
 from django.contrib.auth import login as auth_login
 from django.contrib.auth.models import AbstractUser
@@ -195,8 +196,10 @@ class CompleteCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView)
 
         You may override this method to implement custom logic.
         """
-        user = device.user
-        if not self.request.user.is_authenticated:
+        if self.request.user.is_authenticated:
+            user = device.user
+        else:
+            user = auth_authenticate(self.request, web_authn_credential=device)
             auth_login(self.request, user)
 
         # Mark the user as having passed verification

--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -199,7 +199,7 @@ class CompleteCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView)
         if self.request.user.is_authenticated:
             user = device.user
         else:
-            user = auth_authenticate(self.request, web_authn_credential=device)
+            user = auth_authenticate(self.request, webauthn_credential=device)
             auth_login(self.request, user)
 
         # Mark the user as having passed verification


### PR DESCRIPTION
* Added a very simple django authentication backend to be used with `django.contrib.auth.authenticate()`, `django.contrib.auth.login()`, and `AuthenicationMiddleware`
* Updated `CompleteCredentialAuthenticationView.complete_auth()` to call `django.contrib.auth.authenticate()` before `django.contrib.auth.login()` if the user is not already authenticated via a different authentication backend.

For a more general overview of what happens and how this resolves it, here's how the django auth and login systems work.

* `django.contrib.auth.authenticate()` loops over every backend configured in `settings.AUTH_BACKENDS`, calling the `authenticate()` method on each one and passing in the kwargs passed into `django.contrib.auth.authenticate()`.
* When one returns a user, the `backend` attribute is set on the user to the backend which worked. A backend primarily determines what it will do based on the kwargs passed in. It may do nothing and return `None` but also, In theory, two backends could take the same kwargs but do something different and so still work totally independently and one return `None` and the other return a user.
* `django.contrib.auth.login()` looks at several things.
  * It takes a request, a user, and an optional backend
  * if user is `None` then it sets user to `request.user`
  * It does some mucking about with the session which is irrelevant to what we are doing here
  * It checks to see if the `backend` arg was passed in, preferring that, and then if the user instance has a `backend` attribute set, preferring that next
  * If neither of those (this is where the bug was happening with multiple auth backends configured and using this for the primary, passwordless login rather than secondary 2fa) it checks `settings.AUTHENTICATION_BACKENDS`
  * If there is only one auth backend configured, then it just selects that but if multiple auth backends are configured, then it raises an exception because it doesn't know which one was actually used.
  * It sets a bunch of stuff in the session, sets `request.user` to the user, rotates the csrf token, and sends the `user_logged_in` signal.

This bug was happening if multiple auth backends were configured, which is common, because if this was the primary/only authentication method then no backend was set, so the check for a backend arg and user.backend failed and then the check for only a single auth backend configured failed.

Additionally, once an auth backend is set, which is stored as part of the session, `AuthenticationMiddlware` looks at the session to see which backend was used, and then calls the `get_user()` method on that backend, passing in the user id from the session. I kept this simple and just look up the user directly in that method. I initially considered going through the credential model from `get_credential_model()` but at this point all we have is a user id, so while that could verify that there is some webauthn credential we wouldn't know which one was used and only that one exists now, so just going straight to the user seems just as useful. Arguably going through the credential model at least ensures that some webauthn credential exists and so is probably the one which was used but the views already do enough work around that.

I do feel like maybe more of the logic should actually live in this auth backend, but since we only want to use this backend if the user is not authenticated via a different method and the rest of the auth code is relevant even when using this as 2fa for an already authenticated user, sorting that logic out felt out of scope for this if it is even reasonably possible.