### PR TITLE
Updated the type definitions specifying AbstractUser to instead use AbstractBaseUser

### DIFF
--- a/src/django_otp_webauthn/helpers.py
+++ b/src/django_otp_webauthn/helpers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -176,7 +175,7 @@ class WebAuthnHelper:
 
     def get_authenticator_attachment_preference(
         self,
-    ) -> Optional[AuthenticatorAttachment]:
+    ) -> AuthenticatorAttachment | None:
         """Get the authenticator attachment preference.
 
         By default, this is set to None, which means we don't have a preference.
@@ -379,7 +378,7 @@ class WebAuthnHelper:
         self.create_attestation(device, response.attestation_object, credential.response.client_data_json)
         return device
 
-    def _check_discoverable(self, original_data: dict) -> Optional[bool]:
+    def _check_discoverable(self, original_data: dict) -> bool | None:
         """Check the clientExtensionResults to determine if the credential was
         created as discoverable.
 

--- a/src/django_otp_webauthn/models.py
+++ b/src/django_otp_webauthn/models.py
@@ -1,7 +1,7 @@
 import hashlib
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.db import models
 from django.db.models import QuerySet
 from django.http import HttpRequest
@@ -324,7 +324,7 @@ class AbstractWebAuthnCredential(TimestampMixin, Device):
         return hashlib.sha256(credential_id).digest()
 
     @classmethod
-    def get_credential_descriptors_for_user(cls, user: AbstractUser) -> list[PublicKeyCredentialDescriptor]:
+    def get_credential_descriptors_for_user(cls, user: AbstractBaseUser) -> list[PublicKeyCredentialDescriptor]:
         """Return a list of PublicKeyCredentialDescriptor objects for the given user.
 
         Each PublicKeyCredentialDescriptor object represents a credential that the

--- a/src/django_otp_webauthn/utils.py
+++ b/src/django_otp_webauthn/utils.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from logging import Logger
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
@@ -23,7 +25,7 @@ class rewrite_exceptions:
 
     """
 
-    def __init__(self, logger: Optional[Logger] = None):
+    def __init__(self, logger: Logger | None = None):
         self.logger = logger
 
     def log_exception(self, exc: Exception):

--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -66,9 +66,9 @@ class AuthenticationCeremonyMixin:
         return None
 
     def can_authenticate(self, user: AbstractBaseUser | AnonymousUser | None) -> bool:
-        if user and not user.is_active:
-            return False
-        return True
+        if user and user.is_active:
+            return True
+        return False
 
 
 @method_decorator(never_cache, name="dispatch")


### PR DESCRIPTION
This makes the change from everything specifying `AbstractUser` to `AbstractBaseUser` and additionally adds in corrections for when the user may be `None` or a `django.contrib.auth.models.AnonymousUser`. It is common to subclass `AbstractBaseUser` rather than `AbstractUser` to do things such as provide a model with only an email address field which serves the purpose of the username, customizing fields used for storing the user's name, etc.

Subclassing `AbstractBaseUser` is also what is recommended in the django docs for providing a custom user model. https://docs.djangoproject.com/en/5.0/topics/auth/customizing/#specifying-a-custom-user-model. This is also what `django-stubs` specifies as being returned by `get_user_model()` at https://github.com/typeddjango/django-stubs/blob/e41ffedd0fcfdd04a59ebe3a69b755927e87da62/django-stubs/contrib/auth/__init__.pyi#L31

Since I saw the pipe operator for union types in use already in at least once place, I updated any annotations I touched which were using `Optional[AbstractUser]` to instead use `AbstractBaseUser | None`. This functionality was not added until Python 3.10, so I also added the `__future__` import of `annotations` so that what is currently considered the preferred way of handling these annotations can be used until Python 3.9 reaches its end of life. There are still one or two places using `Optional[Whatever]`, it might be worth updating them for consistency.