### PR TITLE
Revert the change to AuthenticationCeremonyMixin.can_authenticate() logic returning False if the user is falsey.

### DIFF
--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -67,6 +67,9 @@ class AuthenticationCeremonyMixin:
         return None
 
     def can_authenticate(self, user: AbstractBaseUser | AnonymousUser | None) -> bool:
+        # If there is no user, then we are working with an anonymous request
+        # and so the they can autenticate. Otherwise, we have a real user, so they can
+        # only authenticate if they are active.
         if user and user.is_active:
             return True
         return False


### PR DESCRIPTION
This resolves https://github.com/Stormbase/django-otp-webauthn/issues/10 and adds comments explaining why the logic is correct.