### PR TITLE
Fix regression in 0.2.0, rework logic for clarity

### DIFF
--- a/src/django_otp_webauthn/exceptions.py
+++ b/src/django_otp_webauthn/exceptions.py
@@ -24,24 +24,6 @@ class PasswordlessLoginDisabled(OTPWebAuthnApiError):
     default_code = "passwordless_login_disabled"
 
 
-class RegistrationDisabled(OTPWebAuthnApiError):
-    status_code = 403
-    default_detail = _("Registration is disabled.")
-    default_code = "registration_disabled"
-
-
-class AuthenticationDisabled(OTPWebAuthnApiError):
-    status_code = 403
-    default_detail = _("Authentication is disabled.")
-    default_code = "authentication_disabled"
-
-
-class LoginRequired(OTPWebAuthnApiError):
-    status_code = 403
-    default_detail = _("User is not logged in.")
-    default_code = "login_required"
-
-
 class UserDisabled(OTPWebAuthnApiError):
     status_code = 403
     default_detail = _("This user account is marked as disabled.")


### PR DESCRIPTION
Fixes #10 

Replaces #11 

While reviewing #11 and the surrounding code I wrote a couple months ago, I noticed some opportunities for improvement.

- Some of the checks to see if we should allow authentication to proceed were duplicated among `AuthenticationCeremonyMixin` and the `CompleteCredentialAuthenticationView`. This PR addresses that.
- Raise exceptions directly instead of a 'catch all' exception based on the return value of some boolean
- Clean up (now) unused exception classes