### PR TITLE
Pass CSRF token directly as configuration, don't rely on presence of cookie or hidden input

### DIFF
--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -1,5 +1,5 @@
 import { State, Config } from "./types";
-import { getCSRFToken, getConfig } from "./utils";
+import { getConfig } from "./utils";
 import {
   browserSupportsWebAuthn,
   browserSupportsWebAuthnAutofill,
@@ -64,7 +64,7 @@ import {
         method: "POST",
         credentials: "same-origin",
         headers: {
-          "X-CSRFToken": await getCSRFToken(config),
+          "X-CSRFToken": config.csrfToken,
           Accept: "application/json",
         },
       });
@@ -119,7 +119,7 @@ import {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-CSRFToken": await getCSRFToken(config),
+          "X-CSRFToken": config.csrfToken,
         },
         credentials: "same-origin",
         body: JSON.stringify(attResp),
@@ -226,7 +226,7 @@ import {
           method: "POST",
           credentials: "same-origin",
           headers: {
-            "X-CSRFToken": await getCSRFToken(config),
+            "X-CSRFToken": config.csrfToken,
             Accept: "application/json",
           },
         });
@@ -320,7 +320,7 @@ import {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "X-CSRFToken": await getCSRFToken(config),
+            "X-CSRFToken": config.csrfToken,
           },
           credentials: "same-origin",
           body: JSON.stringify(attResp),

--- a/client/src/register.ts
+++ b/client/src/register.ts
@@ -1,5 +1,5 @@
 import { State, Config } from "./types";
-import { getCSRFToken, getConfig } from "./utils";
+import { getConfig } from "./utils";
 import {
   browserSupportsWebAuthn,
   startRegistration,
@@ -50,7 +50,7 @@ import {
           method: "POST",
           credentials: "same-origin",
           headers: {
-            "X-CSRFToken": await getCSRFToken(config),
+            "X-CSRFToken": config.csrfToken,
             Accept: "application/json",
           },
         });
@@ -152,7 +152,7 @@ import {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "X-CSRFToken": await getCSRFToken(config),
+            "X-CSRFToken": config.csrfToken,
           },
           credentials: "same-origin",
           body: JSON.stringify(attResp),

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -16,7 +16,5 @@ export type Config = {
   // The selector for the field that will is supposed to trigger the autofill UI.
   autocompleteLoginFieldSelector?: string;
 
-  // The name of the cookie that contains the CSRF token.
-  // This is configurable because Django has a setting to change it.
-  csrfCookieName: string;
+  csrfToken: string;
 };

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -16,31 +16,3 @@ export async function getConfig(): Promise<Config> {
   }
   throw new Error("otp_webauthn_config element not found");
 }
-
-/**
- * Retrieves the CSRF token from a the cookie or from <input> tag.
- */
-export async function getCSRFToken(config: Config): Promise<string> {
-  let csrfToken = "";
-  const cookieName = config.csrfCookieName;
-  if (document.cookie && document.cookie !== "") {
-    const cookies = document.cookie.split(";");
-    for (let i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i].trim();
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, cookieName.length + 1) === cookieName + "=") {
-        csrfToken = decodeURIComponent(
-          cookie.substring(cookieName.length + 1),
-        );
-        break;
-      }
-    }
-  }
-  if (csrfToken === "") {
-    const input = document.querySelector('input[name="csrfmiddlewaretoken"]');
-    if (input !== null) {
-      csrfToken = input.value;
-    }
-  }
-  return csrfToken;
-}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -18,10 +18,10 @@ export async function getConfig(): Promise<Config> {
 }
 
 /**
- * Retrieves the CSRF token from a the cookie.
+ * Retrieves the CSRF token from a the cookie or from <input> tag.
  */
 export async function getCSRFToken(config: Config): Promise<string> {
-  let cookieValue = "";
+  let csrfToken = "";
   const cookieName = config.csrfCookieName;
   if (document.cookie && document.cookie !== "") {
     const cookies = document.cookie.split(";");
@@ -29,12 +29,18 @@ export async function getCSRFToken(config: Config): Promise<string> {
       const cookie = cookies[i].trim();
       // Does this cookie string begin with the name we want?
       if (cookie.substring(0, cookieName.length + 1) === cookieName + "=") {
-        cookieValue = decodeURIComponent(
+        csrfToken = decodeURIComponent(
           cookie.substring(cookieName.length + 1),
         );
         break;
       }
     }
   }
-  return cookieValue;
+  if (csrfToken === "") {
+    const input = document.querySelector('input[name="csrfmiddlewaretoken"]');
+    if (input !== null) {
+      csrfToken = input.value;
+    }
+  }
+  return csrfToken;
 }

--- a/src/django_otp_webauthn/templatetags/otp_webauthn.py
+++ b/src/django_otp_webauthn/templatetags/otp_webauthn.py
@@ -1,5 +1,6 @@
 from django import template
-from django.conf import settings
+from django.http import HttpRequest
+from django.middleware import csrf
 from django.urls import reverse
 
 from django_otp_webauthn.settings import app_settings
@@ -10,10 +11,10 @@ register = template.Library()
 WebAuthnCredential = get_credential_model()
 
 
-def get_configuration(extra_options: dict = {}) -> dict:
+def get_configuration(request: HttpRequest, extra_options: dict = {}) -> dict:
     configuration = {
         "autocompleteLoginFieldSelector": None,
-        "csrfCookieName": settings.CSRF_COOKIE_NAME,
+        "csrfToken": csrf.get_token(request),
         "beginAuthenticationUrl": reverse("otp_webauthn:credential-authentication-begin"),
         "completeAuthenticationUrl": reverse("otp_webauthn:credential-authentication-complete"),
         "beginRegistrationUrl": reverse("otp_webauthn:credential-registration-begin"),
@@ -26,17 +27,19 @@ def get_configuration(extra_options: dict = {}) -> dict:
 
 @register.inclusion_tag("django_otp_webauthn/auth_scripts.html", takes_context=True)
 def render_otp_webauthn_auth_scripts(context, username_field_selector=None):
+    request = context["request"]
     extra_options = {}
     # If passwordless login is allowed, tell the client-side script what the username field selector is
     # so the field can be marked with the autocomplete="webauthn" attribute to indicate passwordless login is available.
     if app_settings.OTP_WEBAUTHN_ALLOW_PASSWORDLESS_LOGIN:
         extra_options["autocompleteLoginFieldSelector"] = username_field_selector
-    context["configuration"] = get_configuration(extra_options)
+    context["configuration"] = get_configuration(request, extra_options)
 
     return context
 
 
 @register.inclusion_tag("django_otp_webauthn/register_scripts.html", takes_context=True)
 def render_otp_webauthn_register_scripts(context):
-    context["configuration"] = get_configuration()
+    request = context["request"]
+    context["configuration"] = get_configuration(request)
     return context


### PR DESCRIPTION
This works if I manually modify JavaScript, but I have no knowledge of typescript, so there might be something missing.

Fixes #14