### PR TITLE
Clarify custom credential model usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,16 +206,11 @@ Django OTP WebAuthn provides its own models for credentials and attestations for
 Two abstract base models exist with all of the required fields and methods implemented, `django_otp_webauthn.models.AbstractWebAuthnCredential` and `django_otp_webauthn.models.AbstractWebAuthnAttestation`. Your custom attestation will need to override the `credential` field to related back to your own credential model.
 
 ```python
-from django.contrib.sites.models import Site
 from django.db import models
 from django_otp_webauthn.models import AbstractWebAuthnAttestation, AbstractWebAuthnCredential
 
 class MyCredential(AbstractWebAuthnCredential):
-    """
-    A WebAuthn credential associated with a specific site.
-    """
-
-    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    pass
 
 
 class MyAttestation(AbstractWebAuthnAttestation):
@@ -226,7 +221,7 @@ The `AbstractWebAuthnCredential` model creates an index with a name which includ
 
 
 ```python
-class MyCredentiialModelWithALongName(AbstractWebAuthnCredential):
+class MyCredentialModelWithALongName(AbstractWebAuthnCredential):
 
     class Meta:
         indexes = [
@@ -234,14 +229,13 @@ class MyCredentiialModelWithALongName(AbstractWebAuthnCredential):
         ]
 ```
 
-You can also override only the attestation model without any changes to the credential model. When doing so you will still need to override the `credential` field with a `related_name` other than `attestation` to avoid a conflict with the `related_name` property of the default model.
+You can also override only the attestation model without any changes to the credential model. When doing so you will still need to implement the `credential` field to use a `related_name` other than `attestation` to avoid a conflict with the `related_name` property of the default model.
 
 ```python
 from django.db import models
 from django_otp_webauthn.models import AbstractWebAuthnAttestation
 
 class MyAttestation(AbstractWebAuthnAttestation):
-    my_property = models.CharField()
     credential=models.OneToOneField("otp_webauthn.WebAuthnCredential", on_delete=models.CASCADE, related_name="swapped_attestation", editable=False)
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package provides an implementation of [WebAuthn Passkeys](https://passkeys.
     - [Browser compatibility](#browser-compatibility)
   - [Features](#features)
   - [Quick start guide - how to use Passkeys in your Django project](#quick-start-guide---how-to-use-passkeys-in-your-django-project)
+  - [Using custom credential and attestation models](#using-custom-credential-and-attestation-models)
   - [What exactly is a Passkey?](#what-exactly-is-a-passkey)
     - [How Passkeys work (in a nutshell)](#how-passkeys-work-in-a-nutshell)
     - [Why use Passkeys?](#why-use-passkeys)
@@ -197,6 +198,54 @@ If you are exclusively using Passkeys as a secondary verification step, you don'
    ```
 
 9. That's it! You should now see a "Register Passkey" button on your logged-in user template. Clicking this button will start the registration process. After registration, you should see a "Login using a Passkey" button on your login page. Clicking this button will prompt you to use your Passkey to authenticate. Or if your browser supports it, you will be prompted to use your Passkey when you focus the username field.
+
+## Using custom credential and attestation models.
+
+Django OTP WebAuthn provides its own models for credentials and attestations for those credentials. If these do not suit your needs you can also provide your own models. When using a custom credential model them you *must* use a custom attestation model as well.
+
+Two abstract base models exist with all of the required fields and methods implemented, `django_otp_webauthn.models.AbstractWebAuthnCredential` and `django_otp_webauthn.models.AbstractWebAuthnAttestation`. Your custom attestation will need to override the `credential` field to related back to your own credential model.
+
+```python
+from django.contrib.sites.models import Site
+from django.db import models
+from django_otp_webauthn.models import AbstractWebAuthnAttestation, AbstractWebAuthnCredential
+
+class MyCredential(AbstractWebAuthnCredential):
+    """
+    A WebAuthn credential associated with a specific site.
+    """
+
+    site = models.ForeignKey(Site, on_delete=models.CASCADE)
+
+
+class MyAttestation(AbstractWebAuthnAttestation):
+    credential=models.OneToOneField(MyCredential, on_delete=models.CASCADE, related_name="attestation", editable=False)
+```
+
+The `AbstractWebAuthnCredential` model creates an index with a name which includes the concrete model's name with `_sha256_idx` appended to the end. If this combination is longer than 30 characters then you will also need to override the index on your credential model to ensure an appropriate length for the index name.
+
+
+```python
+class MyCredentiialModelWithALongName(AbstractWebAuthnCredential):
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["credential_id_sha256"], name="mycredential_id_sha256_idx"),
+        ]
+```
+
+You can also override only the attestation model without any changes to the credential model. When doing so you will still need to override the `credential` field with a `related_name` other than `attestation` to avoid a conflict with the `related_name` property of the default model.
+
+```python
+from django.db import models
+from django_otp_webauthn.models import AbstractWebAuthnAttestation
+
+class MyAttestation(AbstractWebAuthnAttestation):
+    my_property = models.CharField()
+    credential=models.OneToOneField("otp_webauthn.WebAuthnCredential", on_delete=models.CASCADE, related_name="swapped_attestation", editable=False)
+
+```
+
 
 ## What exactly is a Passkey?
 

--- a/src/django_otp_webauthn/checks.py
+++ b/src/django_otp_webauthn/checks.py
@@ -10,6 +10,7 @@ ERR_UNSUPPORTED_COSE_ALGORITHM = "otp_webauthn.E020"
 ERR_NO_ALLOWED_ORIGINS = "otp_webauthn.E030"
 ERR_ALLOWED_ORIGINS_MALFORMED = "otp_webauthn.E031"
 ERR_DANGEROUS_SESSION_BACKEND = "otp_webauthn.E040"
+ERR_ATTESTATION_MISSING_CREDENTIAL_FIELD = "otp_webauthn.E050"
 
 
 def check_settings_relying_party(app_configs, **kwargs):


### PR DESCRIPTION
This PR is to resolve https://github.com/Stormbase/django-otp-webauthn/issues/21

* Moved `AbstractWebAuthnAttestation.credential` field the concrete `WebAuthnAttestation` model
* Added a check on  `AbstractWebAuthnAttestation` to ensure that there is a `credential` field
* Updated README.md with instructions on how to implement custom models.

The `credential` field was moved because it always needs to be specified by the user. When implementing their own credential model, a custom attestation model with a relation back to their custom credential has to be specified. If implementing only an attestation model then the `credential` field still needs to be overridden or the `related_name` would cause a conflict due to having two models with the same `related_name` pointing at `WebAuthnAttestation`.

A check was added to the `AbstractWebAuthnAttestation` model to ensure that it has a `credential`. We could take that a step further and, if it exists, ensure that it is a `OneToOneField` relating back to an `AbstractWebAuthnCredential`, but a user doesn't technically need subclass that as long as they put the correct fields and methods on their model (although mypy will complain if they use that don't subclass properly).

Locally I added a `swapped_models` app with a handful of models. I'll keep it around for reference. That could be good to make use of when writing a test suite (something I just started looking into doing with hatch the other day).