### PR TITLE
fix(utils): avoid loggin None as exceptin

### DIFF
--- a/src/django_otp_webauthn/utils.py
+++ b/src/django_otp_webauthn/utils.py
@@ -36,6 +36,8 @@ class rewrite_exceptions:
         pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is None:
+            return
         self.log_exception(exc_val)
         if exc_type is pywebauthn_exceptions.InvalidCBORData:
             raise exceptions.UnprocessableEntity(


### PR DESCRIPTION
The rewrite_exceptions logs `None` as exception because `None` is passed to `__exit__` when no exception has been raised (see https://docs.python.org/3/reference/datamodel.html#object.__exit__)