### PR TITLE
Allow only JSON rendering for views

### DIFF
--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -14,6 +14,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.cache import never_cache
 from django_otp import login as otp_login
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -88,6 +89,7 @@ class BeginCredentialRegistrationView(RegistrationCeremonyMixin, APIView):
 
     This view will return a JSON response with the options for the client to use to register a credential.
     """
+    renderer_classes = [JSONRenderer]
 
     def post(self, *args, **kwargs):
         user = self.get_user()
@@ -105,6 +107,7 @@ class CompleteCredentialRegistrationView(RegistrationCeremonyMixin, APIView):
 
     This view accepts client data about the registered credential, validates it, and saves the credential to the database.
     """
+    renderer_classes = [JSONRenderer]
 
     def get_state(self):
         """Retrieve the registration state."""
@@ -138,6 +141,7 @@ class BeginCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView):
 
     This view will return a JSON response with the options for the client to use to authenticate with a credential.
     """
+    renderer_classes = [JSONRenderer]
 
     def post(self, *args, **kwargs):
         user = self.get_user()
@@ -161,6 +165,7 @@ class CompleteCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView)
     This view accepts client data about the registered webauthn , validates it,
     and logs the user in.
     """
+    renderer_classes = [JSONRenderer]
 
     def get_state(self):
         """Retrieve the authentication state."""

--- a/src/django_otp_webauthn/views.py
+++ b/src/django_otp_webauthn/views.py
@@ -89,6 +89,7 @@ class BeginCredentialRegistrationView(RegistrationCeremonyMixin, APIView):
 
     This view will return a JSON response with the options for the client to use to register a credential.
     """
+
     renderer_classes = [JSONRenderer]
 
     def post(self, *args, **kwargs):
@@ -107,6 +108,7 @@ class CompleteCredentialRegistrationView(RegistrationCeremonyMixin, APIView):
 
     This view accepts client data about the registered credential, validates it, and saves the credential to the database.
     """
+
     renderer_classes = [JSONRenderer]
 
     def get_state(self):
@@ -141,6 +143,7 @@ class BeginCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView):
 
     This view will return a JSON response with the options for the client to use to authenticate with a credential.
     """
+
     renderer_classes = [JSONRenderer]
 
     def post(self, *args, **kwargs):
@@ -165,6 +168,7 @@ class CompleteCredentialAuthenticationView(AuthenticationCeremonyMixin, APIView)
     This view accepts client data about the registered webauthn , validates it,
     and logs the user in.
     """
+
     renderer_classes = [JSONRenderer]
 
     def get_state(self):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
+from rest_framework.renderers import JSONRenderer
 
 from django_otp_webauthn import exceptions
 from django_otp_webauthn.helpers import WebAuthnHelper
@@ -34,6 +35,20 @@ def test_views__no_caching_headers_present(rf, view_class, user_in_memory):
         == "max-age=0, no-cache, no-store, must-revalidate, private"
     )
     assert "Expires" in response.headers
+
+
+@pytest.mark.parametrize(
+    "view_class",
+    [
+        BeginCredentialRegistrationView,
+        CompleteCredentialRegistrationView,
+        BeginCredentialAuthenticationView,
+        CompleteCredentialAuthenticationView,
+    ],
+)
+def test_views__no_html_render(view_class):
+    view = view_class()
+    assert view.renderer_classes == [JSONRenderer]
 
 
 def test_pywebauthn_logger(settings):


### PR DESCRIPTION
Set the renderer on the views so only JSON is allowed to be rendered. Without this, there is a `TemplateDoesNotExist` error if the endpoints are visited with a browser.