### PR TITLE
Add support for 'next' query parameter

### DIFF
--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -1,5 +1,5 @@
 import { State, Config, StatusEnum } from "./types";
-import { getConfig } from "./utils";
+import { getConfig, buildCompleteAuthenticationUrl } from "./utils";
 import {
   browserSupportsWebAuthn,
   browserSupportsWebAuthnAutofill,
@@ -107,14 +107,11 @@ import {
         );
         return;
       }
-      // Find out if there is a hidden 'next' field on the page
-      const next = document.querySelector(
-        "input[name='next']",
-      ) as HTMLInputElement;
-      let completeAuthenticationUrl = config.completeAuthenticationUrl;
-      if (next && next.value) {
-        completeAuthenticationUrl += `?next=${encodeURIComponent(next.value)}`;
-      }
+      // Find out if there is a hidden 'next' field on the page,
+      // or if there is a 'next' query parameter in the URL
+      const completeAuthenticationUrl = buildCompleteAuthenticationUrl(
+        config.completeAuthenticationUrl,
+      );
 
       // Complete
       const verificationResp = await fetch(completeAuthenticationUrl, {
@@ -317,14 +314,11 @@ import {
           buttonLabel: gettext("Finishing verification..."),
         });
 
-        // Find out if there is a hidden 'next' field on the page
-        const next = document.querySelector(
-          "input[name='next']",
-        ) as HTMLInputElement;
-        let completeAuthenticationUrl = config.completeAuthenticationUrl;
-        if (next && next.value) {
-          completeAuthenticationUrl += `?next=${encodeURIComponent(next.value)}`;
-        }
+        // Find out if there is a hidden 'next' field on the page,
+        // or if there is a 'next' query parameter in the URL
+        const completeAuthenticationUrl = buildCompleteAuthenticationUrl(
+          config.completeAuthenticationUrl,
+        );
 
         // Complete
         const verificationResp = await fetch(completeAuthenticationUrl, {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -16,3 +16,22 @@ export async function getConfig(): Promise<Config> {
   }
   throw new Error("otp_webauthn_config element not found");
 }
+
+/**
+ * Appends the 'next' query parameter to the base URL if present.
+ * Prefers input[name="next"] if present, otherwise falls back to URL query.
+ */
+export function buildCompleteAuthenticationUrl(baseUrl: string): string {
+  const nextInput =
+    document.querySelector<HTMLInputElement>("input[name='next']");
+  const nextValue =
+    nextInput?.value || new URLSearchParams(window.location.search).get("next");
+
+  if (nextValue) {
+    const url = new URL(baseUrl, window.location.origin);
+    url.searchParams.set("next", nextValue);
+    return url.toString();
+  }
+
+  return baseUrl;
+}

--- a/sandbox/templates/sandbox/login_passkey.html
+++ b/sandbox/templates/sandbox/login_passkey.html
@@ -5,6 +5,7 @@
 {% block title %}{% translate "Login using a Passkey" %}{% endblock %}
 
 {% block content %}
+{% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
 <div>
     <span id="passkey-verification-placeholder"></span>
 </div>

--- a/sandbox/views.py
+++ b/sandbox/views.py
@@ -22,6 +22,12 @@ class IndexView(TemplateView):
 class LoginWithPasskeyView(TemplateView):
     template_name = "sandbox/login_passkey.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Used by E2E tests to test url redirection from an input field on the page
+        context["next"] = self.request.GET.get("next_input", "")
+        return context
+
 
 class SecondFactorVerificationView(LoginRequiredMixin, TemplateView):
     template_name = "sandbox/second_factor_verification.html"


### PR DESCRIPTION
Fixes #52

Disclaimer: I've never written a line of typescript in my life so bear with me, but how hard can it be right?

This PR adds functionality to redirect users to the location of `/?next=` query parameter. It prefers the `input[name="next"]` element, as Django does as well: https://github.com/django/django/blob/0ee06c04e0256094270db3ffe8b5dafa6a8457a3/django/contrib/auth/views.py#L45