### PR TITLE
Documentation: Add documentation feedback issue template and link to announcement banner in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,44 @@
+name: Feedback on Django OTP WebAuthn documentation
+description: Provide feedback on the Django OTP WebAuthn documentation.
+title: "[Feedback]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this feedback!**
+        We really appreciate your input, and it will help us improve the documentation.
+        
+        Please provide an appropriate title at the top of this page.
+        
+        ---
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Please enter the URL of the page you are referring to.
+      placeholder: For example, https://django-otp-webauthn.readthedocs.io/en/latest/
+    validations:
+      required: true
+  - type: checkboxes
+    id: content
+    attributes:
+      label: Select all that apply
+      description: Please let us know what issue you encountered with the documentation.
+      options:
+        - label: I found what I was looking for
+        - label: I couldn't find what I was looking for
+        - label: I found the information, but it was incorrect
+        - label: I found the information, but it was incomplete
+        - label: I found the information, but it was confusing
+        - label: I encountered a technical issue (e.g., broken link, incorrect code snippet)
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,6 +1,7 @@
 name: Feedback on Django OTP WebAuthn documentation
 description: Provide feedback on the Django OTP WebAuthn documentation.
 title: "[Feedback]: "
+labels: ["Documentation"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -7,9 +7,9 @@ body:
       value: |
         **Thanks for taking the time to fill out this feedback!**
         We really appreciate your input, and it will help us improve the documentation.
-        
+
         Please provide an appropriate title at the top of this page.
-        
+
         ---
   - type: input
     id: page_url

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,5 +33,5 @@ html_theme_options = {
     "source_repository": "https://github.com/Stormbase/django-otp-webauthn",
     "source_branch": "main",
     "source_directory": "docs/",
-    "announcement": "<div><strong>📢Announcement:</strong> Django OTP WebAuthn is still pretty new. Please report any issues or suggestions on <a href='https://github.com/Stormbase/django-otp-webauthn/issues/new?template=feedback.yml'>GitHub Issues</a>.</div>",
+    "announcement": "<div><strong>📢Announcement:</strong> Django OTP WebAuthn is still pretty new. Please report any issues or suggestions on <a href='https://github.com/Stormbase/django-otp-webauthn/issues/new?template=feedback.yml' target='_blank' rel='noopener noreferrer'>GitHub Issues</a>.</div>",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,5 +33,5 @@ html_theme_options = {
     "source_repository": "https://github.com/Stormbase/django-otp-webauthn",
     "source_branch": "main",
     "source_directory": "docs/",
-    "announcement": "<div><strong>📢Announcement:</strong> Django OTP WebAuthn is still pretty new. Please report any issues or suggestions on <a href='https://github.com/Stormbase/django-otp-webauthn/issues'>GitHub Issues</a>.</div>",
+    "announcement": "<div><strong>📢Announcement:</strong> Django OTP WebAuthn is still pretty new. Please report any issues or suggestions on <a href='https://github.com/Stormbase/django-otp-webauthn/issues/new?template=feedback.yml'>GitHub Issues</a>.</div>",
 }


### PR DESCRIPTION
This PR adds a dedicated issue template for collecting feedback on the Django OTP WebAuthn documentation, solving issue #70. The goal is to provide clearer guidance for users who:

- encounter issues with the documentation (e.g., incorrect, incomplete, or confusing information)
- want to suggest improvements
- experience technical problems like broken links or incorrect code snippets

> **Note:** _The issue template won't work until this PR is merged into the default branch. This is because GitHub loads templates from the .github/ISSUE_TEMPLATE directory on the default branch only. Templates created in a non-default branch won’t appear in the issue creation flow for collaborators. See [About templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)._

You can view a working example of this kind of template in a test repository I set up here:
https://github.com/activus-d/test-issue-template/issues/new?template=feedback.yml

