### PR TITLE
feat: allow custom selector for 'next' field in auth config

### DIFF
--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -111,6 +111,7 @@ import {
       // or if there is a 'next' query parameter in the URL
       const completeAuthenticationUrl = buildCompleteAuthenticationUrl(
         config.completeAuthenticationUrl,
+        config.nextFieldSelector,
       );
 
       // Complete
@@ -318,6 +319,7 @@ import {
         // or if there is a 'next' query parameter in the URL
         const completeAuthenticationUrl = buildCompleteAuthenticationUrl(
           config.completeAuthenticationUrl,
+          config.nextFieldSelector,
         );
 
         // Complete

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -28,6 +28,7 @@ export type Config = {
 
   // The selector for the field that will is supposed to trigger the autofill UI.
   autocompleteLoginFieldSelector?: string;
+  nextFieldSelector?: string;
 
   csrfToken: string;
 };

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -21,9 +21,12 @@ export async function getConfig(): Promise<Config> {
  * Appends the 'next' query parameter to the base URL if present.
  * Prefers input[name="next"] if present, otherwise falls back to URL query.
  */
-export function buildCompleteAuthenticationUrl(baseUrl: string): string {
-  const nextInput =
-    document.querySelector<HTMLInputElement>("input[name='next']");
+export function buildCompleteAuthenticationUrl(
+  baseUrl: string,
+  nextFieldSelectorQuery?: string,
+): string {
+  const nextInputSelector = nextFieldSelectorQuery || "input[name='next']";
+  const nextInput = document.querySelector<HTMLInputElement>(nextInputSelector);
   const nextValue =
     nextInput?.value || new URLSearchParams(window.location.search).get("next");
 

--- a/src/django_otp_webauthn/templatetags/otp_webauthn.py
+++ b/src/django_otp_webauthn/templatetags/otp_webauthn.py
@@ -11,6 +11,7 @@ register = template.Library()
 def get_configuration(request: HttpRequest, extra_options: dict = {}) -> dict:
     configuration = {
         "autocompleteLoginFieldSelector": None,
+        "nextFieldSelector": None,
         "csrfToken": csrf.get_token(request),
         "beginAuthenticationUrl": reverse(
             "otp_webauthn:credential-authentication-begin"
@@ -29,13 +30,18 @@ def get_configuration(request: HttpRequest, extra_options: dict = {}) -> dict:
 
 
 @register.inclusion_tag("django_otp_webauthn/auth_scripts.html", takes_context=True)
-def render_otp_webauthn_auth_scripts(context, username_field_selector=None):
+def render_otp_webauthn_auth_scripts(
+    context, username_field_selector=None, next_field_selector=None
+):
     request = context["request"]
     extra_options = {}
     # If passwordless login is allowed, tell the client-side script what the username field selector is
     # so the field can be marked with the autocomplete="webauthn" attribute to indicate passwordless login is available.
     if app_settings.OTP_WEBAUTHN_ALLOW_PASSWORDLESS_LOGIN:
         extra_options["autocompleteLoginFieldSelector"] = username_field_selector
+
+    extra_options["nextFieldSelector"] = next_field_selector
+
     context["configuration"] = get_configuration(request, extra_options)
 
     return context


### PR DESCRIPTION
### Summary

Adds support for passing a custom selector for the `next` input field during authentication.

This improves compatibility with custom login forms that do not use `input[name='next']`.
It also helps in more complex Django pages where multiple forms exist – for example,
a language switcher or localized login view might contain additional forms with their
own `next` field, making a custom selector necessary to target the correct one.

### Changes

- Added `nextFieldSelector` to TS config
- Extended `buildCompleteAuthenticationUrl()` to support custom selector
- Updated Django template tag `render_otp_webauthn_auth_scripts`