### PR TITLE
Add support for Django 6.0 (pending final release) / drop Django 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 env_list =
     py{39,310,311,312}-django42
     py{310,311,312,313}-django{50,51,52}
+    py{312,313}-django60
 minversion = 4.18.1
 
 [testenv]
@@ -21,6 +22,7 @@ deps =
     django50: django~=5.0.0
     django51: django~=5.1.0
     django52: django~=5.2.0
+    django60: django~=6.0.0a1
 
 [testenv:future]
 env =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     py{39,310,311,312}-django42
-    py{310,311,312,313}-django{50,51,52}
+    py{310,311,312,313}-django{51,52}
     py{312,313}-django60
 minversion = 4.18.1
 
@@ -19,7 +19,6 @@ basepython =
 
 deps =
     django42: django~=4.2.0
-    django50: django~=5.0.0
     django51: django~=5.1.0
     django52: django~=5.2.0
     django60: django~=6.0.0a1


### PR DESCRIPTION
Start testing against the current alpha release.