### PR TITLE
Add optional Docker build workflow and improve translation update script

### DIFF
--- a/client/Dockerfile.client
+++ b/client/Dockerfile.client
@@ -1,0 +1,10 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache python3 make g++ \
+  && corepack enable || true
+
+WORKDIR /app/client
+
+CMD ["sh", "-c", "yarn install && yarn build"]

--- a/scripts/update_translations.sh
+++ b/scripts/update_translations.sh
@@ -1,13 +1,37 @@
 #!/bin/sh
 
-# This script is used to update and manage translations.
+# -----------------------------------------------------------------------------
+# Translation update helper for django_otp_webauthn
+#
+# This script updates translation catalogs for both Python/Template code
+# (django.po) and JavaScript code (djangojs.po).
+#
 # Usage:
 #
-# Update all languages:
-# ./update_translations.sh --all
+#   Update all languages:
+#       ./update_translations.sh --all
 #
-# Create or update existing language:
-# ./update_translations.sh -l <language_code>
+#   Create or update a specific language:
+#       ./update_translations.sh -l <language_code>
+#
+# JavaScript translations
+# -----------------------
+# JavaScript messages are extracted from the compiled Webpack output.
+# Therefore, static assets must be built before updating djangojs.po.
+#
+#   Local Node/Yarn environment:
+#       cd client && yarn install && yarn build
+#
+#   Without Node/Yarn installed on the host:
+#       docker build -f client/Dockerfile.client -t otp-webauthn-client .
+#       docker run --rm -v "$PWD:/app" otp-webauthn-client
+#
+# After compiling the static assets, run this script again normally.
+#
+# Python/Django translations
+# --------------------------
+# The django.po catalogs are extracted from Python sources and templates.
+# -----------------------------------------------------------------------------
 
 # If no arguments are provided, show usage
 if [ "$#" -eq 0 ]; then
@@ -20,11 +44,7 @@ set -e
 IGNORE_PATHS="--ignore venv --ignore client --ignore .tox --ignore dist --ignore node_modules --ignore docs"
 
 echo "Updating djangojs.po files..."
-# Update JavaScript translations
-# Note: static must be compiled before running this command: `cd client && yarn build`
-# Note: source locations are omitted because they refer to the compiled files, not the source files
 python manage.py makemessages $IGNORE_PATHS -d djangojs --no-location --no-obsolete $@
 
 echo "\nUpdating django.po files..."
-# Update Django translations
 python manage.py makemessages $IGNORE_PATHS --no-obsolete $@


### PR DESCRIPTION
This PR introduces two developer-experience improvements related to translation handling and JavaScript asset generation.

1. Optional Docker workflow for compiling static assets

JavaScript translations (djangojs.po) are extracted from the compiled Webpack bundles.
Until now, contributors needed a local Node/Yarn setup in order to build these assets.

This PR adds an optional Dockerfile (client/Dockerfile.client) that allows contributors to compile the static files in an isolated container:

```bash
docker build -f client/Dockerfile.client -t otp-webauthn-client .
docker run --rm -v "$PWD:/app" otp-webauthn-client
````

This setup is fully optional.
Existing workflows that rely on locally installed Node/Yarn continue to work unchanged.

2. Improved documentation in update_translations.sh

The translation update script now contains clearer instructions on:
- when JavaScript assets must be compiled,
- how to update translations for new locales,
- how to use the optional Docker workflow if Node/Yarn are not available,
- and the distinction between django.po and djangojs.po.

No functional changes were made to the script itself.
