### PR TITLE
Add italien (it) and spanish (es) translations

### DIFF
--- a/src/django_otp_webauthn/locale/es/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,160 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-06 12:33+0000\n"
+"PO-Revision-Date: 2026-01-06 13:49+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#: src/django_otp_webauthn/admin.py:38
+msgid "COSE public key"
+msgstr "Clave pública COSE"
+
+#: src/django_otp_webauthn/admin.py:62
+msgid "Identity"
+msgstr "Identidad"
+
+#: src/django_otp_webauthn/admin.py:68
+msgid "Meta"
+msgstr "Meta"
+
+#: src/django_otp_webauthn/admin.py:74
+msgid "WebAuthn credential data"
+msgstr "Datos de credenciales de WebAuthn"
+
+#: src/django_otp_webauthn/apps.py:11
+msgid "OTP WebAuthn"
+msgstr "OTP WebAuthn"
+
+#: src/django_otp_webauthn/exceptions.py:12
+msgid ""
+"State is missing or invalid. Please begin the operation first before trying "
+"to complete it."
+msgstr ""
+"El estado falta o no es válido. Inicie la operación antes de intentar "
+"completarla."
+
+#: src/django_otp_webauthn/exceptions.py:19
+msgid "Unprocessable Entity"
+msgstr "Entidad no procesable"
+
+#: src/django_otp_webauthn/exceptions.py:25
+msgid "Passwordless login is disabled."
+msgstr "El inicio de sesión sin contraseña está deshabilitado."
+
+#: src/django_otp_webauthn/exceptions.py:31
+msgid "This user account is marked as disabled."
+msgstr "Esta cuenta de usuario está marcada como deshabilitada."
+
+#: src/django_otp_webauthn/exceptions.py:37
+msgid "This Passkey has been marked as disabled."
+msgstr "Esta clave de acceso ha sido marcada como deshabilitada."
+
+#: src/django_otp_webauthn/exceptions.py:44
+msgid "The Passkey you tried to use was not found. Perhaps it was removed?"
+msgstr "No se encontró la clave que intentó usar. ¿Quizas fue eliminada?"
+
+#: src/django_otp_webauthn/models.py:86
+msgid "format"
+msgstr "formato"
+
+#: src/django_otp_webauthn/models.py:90
+msgid "data"
+msgstr "datos"
+
+#: src/django_otp_webauthn/models.py:94
+msgid "client data JSON"
+msgstr "datos del cliente JSON"
+
+#: src/django_otp_webauthn/models.py:106
+msgid "WebAuthn attestation"
+msgstr "Certificación WebAuthn"
+
+#: src/django_otp_webauthn/models.py:107
+msgid "WebAuthn attestations"
+msgstr "Certificaciones de WebAuthn"
+
+#: src/django_otp_webauthn/models.py:148
+msgid "WebAuthn credential"
+msgstr "Credencial de WebAuthn"
+
+#: src/django_otp_webauthn/models.py:149
+msgid "WebAuthn credentials"
+msgstr "Credenciales de WebAuthn"
+
+#: src/django_otp_webauthn/models.py:156
+msgid "Public Key"
+msgstr "Clave pública"
+
+#: src/django_otp_webauthn/models.py:161
+msgid "credential type"
+msgstr "tipo de credencial"
+
+#: src/django_otp_webauthn/models.py:174
+msgid "credential id data"
+msgstr "datos de identificación de credenciales"
+
+#: src/django_otp_webauthn/models.py:191
+msgid "COSE public key data"
+msgstr "Datos de clave pública de COSE"
+
+#: src/django_otp_webauthn/models.py:199
+msgid "transports"
+msgstr "transportes"
+
+#: src/django_otp_webauthn/models.py:219
+msgid "sign count"
+msgstr "recuento de signos"
+
+#: src/django_otp_webauthn/models.py:237
+msgid "backup eligible"
+msgstr "elegible para respaldo"
+
+#: src/django_otp_webauthn/models.py:247
+msgid "backup state"
+msgstr "estado de respaldo"
+
+#: src/django_otp_webauthn/models.py:270
+msgid "AAGUID"
+msgstr "AAGUID"
+
+#: src/django_otp_webauthn/models.py:287
+msgid "hashed credential id"
+msgstr "ID de credencial hash"
+
+#: src/django_otp_webauthn/models.py:296
+msgid "discoverable"
+msgstr "localizable"
+
+#: src/django_otp_webauthn/models.py:402
+msgid "credential"
+msgstr "credencial"
+
+#: src/django_otp_webauthn/models.py:428
+msgid "handle hex"
+msgstr "mango hexagonal"
+
+#: src/django_otp_webauthn/models.py:438
+msgid "user"
+msgstr "usuario"
+
+#: src/django_otp_webauthn/models.py:442
+msgid "WebAuthn user handle"
+msgstr "Identificador de usuario de WebAuthn"
+
+#: src/django_otp_webauthn/models.py:443
+msgid "WebAuthn user handles"
+msgstr "Identificadores de usuarios de WebAuthn"

--- a/src/django_otp_webauthn/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/django_otp_webauthn/locale/es/LC_MESSAGES/djangojs.po
@@ -1,0 +1,105 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-06 12:33+0000\n"
+"PO-Revision-Date: 2026-01-06 13:51+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+msgid "Verification failed. A server error occurred."
+msgstr "Error de verificación. Se produjo un error en el servidor."
+
+msgid "An error occurred during verification."
+msgstr "Se produjo un error durante la verificación."
+
+msgid "Verify with Passkey"
+msgstr "Verificar con clave de acceso"
+
+msgid "Verifying..."
+msgstr "Verificando…"
+
+msgid "Verification failed. Could not retrieve parameters from the server."
+msgstr ""
+"Error en la verificación. No se pudieron recuperar los parámetros del "
+"servidor."
+
+msgid "Verification aborted."
+msgstr "Verificación abortada."
+
+msgid "Verification canceled or not allowed."
+msgstr "Verificación cancelada o no permitida."
+
+msgid "Verification failed. An unknown error occurred."
+msgstr "Error de verificación. Se produjo un error desconocido."
+
+msgid "Finishing verification..."
+msgstr "Finalizando verificación…"
+
+msgid "Verification failed. An unknown server error occurred."
+msgstr ""
+"Error de verificación. Se produjo un error desconocido en el servidor."
+
+msgid "Verification successful!"
+msgstr "¡Verificación exitosa!"
+
+msgid "Register a Passkey"
+msgstr "Registrar una clave de acceso"
+
+msgid "Registering..."
+msgstr "Registrando…"
+
+msgid "Registration failed. Unable to fetch registration options from server."
+msgstr ""
+"Error en el registro. No se pueden obtener las opciones de registro del "
+"servidor."
+
+msgid "Registration aborted."
+msgstr "Registro abortado."
+
+msgid ""
+"Registration failed. You most likely already have a Passkey registered for "
+"this site."
+msgstr ""
+"Error en el registro. Probablemente ya tenga una clave de acceso registrada "
+"para este sitio"
+
+msgid "Registration aborted or not allowed."
+msgstr "Registro abortado o no permitido."
+
+msgid ""
+"Registration failed. A technical problem occurred that prevents you from "
+"registering a Passkey for this site."
+msgstr ""
+"Error en el registro. Se produjo un problema técnico que le impide "
+"registrar una clave de acceso para este sitio."
+
+msgid "Registration failed. An unknown error occurred."
+msgstr "Error en el registro. Se produjo un error desconocido."
+
+msgid "Finishing registration..."
+msgstr "Finalizando registro…"
+
+msgid "Registration failed. The server was unable to verify this passkey."
+msgstr "Error en el registro. El servidor no pudo verificar esta clave."
+
+msgid "Registration failed. A server error occurred."
+msgstr "Error en el registro. Se produjo un error en el servidor."
+
+msgid "Registration successful!"
+msgstr "¡Registro exitoso!"
+
+msgid "An error occurred during registration."
+msgstr "Se produjo un error durante el registro."

--- a/src/django_otp_webauthn/locale/it/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,162 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-06 12:33+0000\n"
+"PO-Revision-Date: 2026-01-06 13:54+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#: src/django_otp_webauthn/admin.py:38
+msgid "COSE public key"
+msgstr "Chiave pubblica COSE"
+
+#: src/django_otp_webauthn/admin.py:62
+msgid "Identity"
+msgstr "Identità"
+
+#: src/django_otp_webauthn/admin.py:68
+msgid "Meta"
+msgstr "Meta"
+
+#: src/django_otp_webauthn/admin.py:74
+msgid "WebAuthn credential data"
+msgstr "Dati delle credenziali WebAuthn"
+
+#: src/django_otp_webauthn/apps.py:11
+msgid "OTP WebAuthn"
+msgstr "OTP WebAuthn"
+
+#: src/django_otp_webauthn/exceptions.py:12
+msgid ""
+"State is missing or invalid. Please begin the operation first before trying "
+"to complete it."
+msgstr ""
+"Lo stato è mancante o non valido. Si prega di avviare il processo prima di "
+"tentare di completarlo."
+
+#: src/django_otp_webauthn/exceptions.py:19
+msgid "Unprocessable Entity"
+msgstr "Entità non elaborabile"
+
+#: src/django_otp_webauthn/exceptions.py:25
+msgid "Passwordless login is disabled."
+msgstr "L’accesso senza password è disabilitato."
+
+#: src/django_otp_webauthn/exceptions.py:31
+msgid "This user account is marked as disabled."
+msgstr "Questo account utente è contrassegnato come disabilitato."
+
+#: src/django_otp_webauthn/exceptions.py:37
+msgid "This Passkey has been marked as disabled."
+msgstr "Questa passkey è stata contrassegnata come disabilitata."
+
+#: src/django_otp_webauthn/exceptions.py:44
+msgid "The Passkey you tried to use was not found. Perhaps it was removed?"
+msgstr ""
+"La passkey che hai provato a usare non è stata trovata. Forse è stata "
+"rimossa?"
+
+#: src/django_otp_webauthn/models.py:86
+msgid "format"
+msgstr "formato"
+
+#: src/django_otp_webauthn/models.py:90
+msgid "data"
+msgstr "dati"
+
+#: src/django_otp_webauthn/models.py:94
+msgid "client data JSON"
+msgstr "dati del cliente JSON"
+
+#: src/django_otp_webauthn/models.py:106
+msgid "WebAuthn attestation"
+msgstr "Attestazione WebAuthn"
+
+#: src/django_otp_webauthn/models.py:107
+msgid "WebAuthn attestations"
+msgstr "Attestazioni WebAuthn"
+
+#: src/django_otp_webauthn/models.py:148
+msgid "WebAuthn credential"
+msgstr "Credenziale WebAuthn"
+
+#: src/django_otp_webauthn/models.py:149
+msgid "WebAuthn credentials"
+msgstr "Credenziali WebAuthn"
+
+#: src/django_otp_webauthn/models.py:156
+msgid "Public Key"
+msgstr "Chiave pubblica"
+
+#: src/django_otp_webauthn/models.py:161
+msgid "credential type"
+msgstr "Tipo di autorizzazione"
+
+#: src/django_otp_webauthn/models.py:174
+msgid "credential id data"
+msgstr "Dati dell’ID di autorizzazione"
+
+#: src/django_otp_webauthn/models.py:191
+msgid "COSE public key data"
+msgstr "Dati della chiave pubblica COSE"
+
+#: src/django_otp_webauthn/models.py:199
+msgid "transports"
+msgstr "trasporti"
+
+#: src/django_otp_webauthn/models.py:219
+msgid "sign count"
+msgstr "conteggio delle firme"
+
+#: src/django_otp_webauthn/models.py:237
+msgid "backup eligible"
+msgstr "idoneo al backup"
+
+#: src/django_otp_webauthn/models.py:247
+msgid "backup state"
+msgstr "stato del backup"
+
+#: src/django_otp_webauthn/models.py:270
+msgid "AAGUID"
+msgstr "AAGUID"
+
+#: src/django_otp_webauthn/models.py:287
+msgid "hashed credential id"
+msgstr "ID della credenziale con hash"
+
+#: src/django_otp_webauthn/models.py:296
+msgid "discoverable"
+msgstr "individuabile"
+
+#: src/django_otp_webauthn/models.py:402
+msgid "credential"
+msgstr "credenziale"
+
+#: src/django_otp_webauthn/models.py:428
+msgid "handle hex"
+msgstr "User Handle esadecimale"
+
+#: src/django_otp_webauthn/models.py:438
+msgid "user"
+msgstr "utente"
+
+#: src/django_otp_webauthn/models.py:442
+msgid "WebAuthn user handle"
+msgstr "Utente Handle WebAuthn"
+
+#: src/django_otp_webauthn/models.py:443
+msgid "WebAuthn user handles"
+msgstr "Utenti Handles WebAuthn"

--- a/src/django_otp_webauthn/locale/it/LC_MESSAGES/djangojs.po
+++ b/src/django_otp_webauthn/locale/it/LC_MESSAGES/djangojs.po
@@ -1,0 +1,103 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-06 12:33+0000\n"
+"PO-Revision-Date: 2026-01-06 13:55+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+msgid "Verification failed. A server error occurred."
+msgstr "Verifica fallita. Si è verificato un errore del server."
+
+msgid "An error occurred during verification."
+msgstr "Si è verificato un errore durante la verifica."
+
+msgid "Verify with Passkey"
+msgstr "Verifica con Passkey"
+
+msgid "Verifying..."
+msgstr "Verifica in corso…"
+
+msgid "Verification failed. Could not retrieve parameters from the server."
+msgstr "Verifica fallita. Impossibile recuperare i parametri dal server."
+
+msgid "Verification aborted."
+msgstr "Verifica interrotta."
+
+msgid "Verification canceled or not allowed."
+msgstr "Verifica annullata o non consentita."
+
+msgid "Verification failed. An unknown error occurred."
+msgstr "Verifica non riuscita. Si è verificato un errore sconosciuto."
+
+msgid "Finishing verification..."
+msgstr "Completamento della verifica…"
+
+msgid "Verification failed. An unknown server error occurred."
+msgstr "Verifica fallita. Si è verificato un errore sconosciuto del server."
+
+msgid "Verification successful!"
+msgstr "Verifica avvenuta con successo!"
+
+msgid "Register a Passkey"
+msgstr "Registra una passkey"
+
+msgid "Registering..."
+msgstr "Registrazione in corso…"
+
+msgid "Registration failed. Unable to fetch registration options from server."
+msgstr ""
+"Registrazione fallita. Impossibile recuperare le opzioni di registrazione "
+"dal server."
+
+msgid "Registration aborted."
+msgstr "Registrazione interrotta."
+
+msgid ""
+"Registration failed. You most likely already have a Passkey registered for "
+"this site."
+msgstr ""
+"Registrazione fallita. Molto probabilmente hai già una Passkey registrata "
+"per questo sito."
+
+msgid "Registration aborted or not allowed."
+msgstr "Registrazione annullata o non consentita."
+
+msgid ""
+"Registration failed. A technical problem occurred that prevents you from "
+"registering a Passkey for this site."
+msgstr ""
+"Registrazione fallita. Si è verificato un problema tecnico che impedisce la "
+"registrazione di una Passkey per questo sito."
+
+msgid "Registration failed. An unknown error occurred."
+msgstr "Registrazione fallita. Si è verificato un errore sconosciuto."
+
+msgid "Finishing registration..."
+msgstr "Completamento della registrazione…"
+
+msgid "Registration failed. The server was unable to verify this passkey."
+msgstr ""
+"Registrazione fallita. Il server non è riuscito a verificare questa passkey."
+
+msgid "Registration failed. A server error occurred."
+msgstr "Registrazione fallita. Si è verificato un errore del server."
+
+msgid "Registration successful!"
+msgstr "Registrazione avvenuta con successo!"
+
+msgid "An error occurred during registration."
+msgstr "Si è verificato un errore durante la registrazione."


### PR DESCRIPTION
This PR adds a complete italien and spanish locales for the project, verified by native speakers.

Included

src/django_otp_webauthn/locale/es/LC_MESSAGES/django.po
src/django_otp_webauthn/locale/es/LC_MESSAGES/djangojs.po
src/django_otp_webauthn/locale/it/LC_MESSAGES/django.po
src/django_otp_webauthn/locale/it/LC_MESSAGES/djangojs.po
