### PR TITLE
Add UnenrolledModelBackend and UnenrolledAuthenticationMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,33 @@ To quickly start using Passkeys in your Django project, follow these steps:
 
 6. Add `django_otp_webauthn.backends.WebAuthnBackend` to `AUTHENTICATION_BACKENDS` in your Django settings. This step is required to make 'passwordless authentication' work.
 
-If you are exclusively using Passkeys as a secondary verification step, you don't have to add this backend.
+   If you are exclusively using Passkeys as a secondary verification step, you don't have to add this backend.
 
-```python
-# settings.py
+   ```python
+   # settings.py
 
-AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",  # This is Django's default backend, you likely want to keep it.
-    ...
-    "django_otp_webauthn.backends.WebAuthnBackend",
-    ...
-]
-```
+   AUTHENTICATION_BACKENDS = [
+       "django.contrib.auth.backends.ModelBackend",  # This is Django's default backend, you likely want to keep it.
+       ...
+       "django_otp_webauthn.backends.WebAuthnBackend",
+       ...
+   ]
+   ```
+
+   ### Optional: prevent password login for users with passkeys
+
+   By default, a user who has registered a Passkey can still log in with their password. To disable this, replace `django.contrib.auth.backends.ModelBackend` with `django_otp_webauthn.backends.UnenrolledModelBackend`:
+
+   ```python
+   # settings.py
+
+   AUTHENTICATION_BACKENDS = [
+       "django_otp_webauthn.backends.WebAuthnBackend",
+       "django_otp_webauthn.backends.UnenrolledModelBackend",
+   ]
+   ```
+
+   Password authentication will then only work for users who have not yet registered a Passkey, allowing them to log in to register their first one. Once a user has a confirmed Passkey, password login will fail for that account as though a wrong password was used.
 
 7. Add the registration code to your logged-in user template.
 

--- a/src/django_otp_webauthn/backends.py
+++ b/src/django_otp_webauthn/backends.py
@@ -1,10 +1,12 @@
 from typing import Any, Optional
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import HttpRequest
 
 from django_otp_webauthn.models import AbstractWebAuthnCredential
+from django_otp_webauthn.utils import get_credential_model
 
 UserModel = get_user_model()
 
@@ -36,3 +38,29 @@ class WebAuthnBackend:
         that attribute are allowed.
         """
         return bool(user and getattr(user, "is_active", True))
+
+
+class UnenrolledAuthenticationMixin:
+    """Mixin for backend to authenticate users only if they are not enrolled with any
+    WebAuthn credentials.
+    """
+
+    def authenticate(self, request, **kwargs):
+        user = super().authenticate(request, **kwargs)
+        if user is not None and _has_confirmed_credential(user):
+            return None
+        return user
+
+
+class UnenrolledModelBackend(UnenrolledAuthenticationMixin, ModelBackend):
+    """A drop-in replacement for ModelBackend that only authenticates users who are not
+    enrolled with any WebAuthn credentials.
+
+    Intended for use with passwordless authentication to prevent password-based attacks
+    against users enrolled with WebAuthn credentials.
+    """
+
+
+def _has_confirmed_credential(user):
+    """Returns True if the user has a confirmed WebAuthn credential."""
+    return get_credential_model().objects.filter(user=user, confirmed=True).exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from tests.factories import (
     WebAuthnUserHandleFactory,
 )
 
+CORRECT_PASSWORD = "password"  # noqa: S105
+
 
 def _load_json_schema(path):
     json_schema_path = pathlib.Path(settings.BASE_DIR) / path
@@ -62,6 +64,13 @@ def credential():
 
 
 @pytest.fixture
+def credential_with_password(credential):
+    credential.user.set_password(CORRECT_PASSWORD)
+    credential.user.save()
+    return credential
+
+
+@pytest.fixture
 def user_handle():
     return WebAuthnUserHandleFactory()
 
@@ -69,6 +78,13 @@ def user_handle():
 @pytest.fixture
 def user():
     return UserFactory()
+
+
+@pytest.fixture
+def user_with_password(user):
+    user.set_password(CORRECT_PASSWORD)
+    user.save()
+    return user
 
 
 @pytest.fixture

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,6 +1,7 @@
 import pytest
 
-from django_otp_webauthn.backends import WebAuthnBackend
+from django_otp_webauthn.backends import UnenrolledModelBackend, WebAuthnBackend
+from tests.conftest import CORRECT_PASSWORD
 
 
 def test_webauthn_backend__authenticate__no_webauthn_credential_parameter(rf):
@@ -44,3 +45,86 @@ def test_webauthn_backend__get_user__user_does_not_exist():
 def test_webauthn_backend__get_user__user_exists(user):
     backend = WebAuthnBackend()
     assert backend.get_user(user.pk) == user
+
+
+@pytest.mark.django_db
+def test_unenrolled_model_backend__authenticate__webauthn_credential(
+    rf, credential_with_password
+):
+    request = rf.get("/")
+    backend = UnenrolledModelBackend()
+
+    user = backend.authenticate(
+        request,
+        username=credential_with_password.user.username,
+        password=CORRECT_PASSWORD,
+    )
+    assert user is None
+
+    user = backend.authenticate(
+        request,
+        username=credential_with_password.user.username,
+        password="incorrect",  # noqa: S106
+    )
+    assert user is None
+
+
+@pytest.mark.django_db
+def test_unenrolled_model_backend__authenticate__unconfirmed_webauthn_credential(
+    rf, credential_with_password
+):
+    request = rf.get("/")
+    backend = UnenrolledModelBackend()
+    credential_with_password.confirmed = False
+    credential_with_password.save()
+
+    user = backend.authenticate(
+        request,
+        username=credential_with_password.user.username,
+        password=CORRECT_PASSWORD,
+    )
+    assert user == credential_with_password.user
+
+    user = backend.authenticate(
+        request,
+        username=credential_with_password.user.username,
+        password="incorrect",  # noqa: S106
+    )
+    assert user is None
+
+
+@pytest.mark.django_db
+def test_unenrolled_model_backend__authenticate__password_only(rf, user_with_password):
+    request = rf.get("/")
+    backend = UnenrolledModelBackend()
+
+    authenticated_user = backend.authenticate(
+        request,
+        username=user_with_password.username,
+        password=CORRECT_PASSWORD,
+    )
+    assert authenticated_user == user_with_password
+
+    authenticated_user = backend.authenticate(
+        request,
+        username=user_with_password.username,
+        password="incorrect",  # noqa: S106
+    )
+    assert authenticated_user is None
+
+
+@pytest.mark.django_db
+def test_unenrolled_model_backend__authenticate__enrolled_and_unenrolled_users(
+    rf, user_with_password, credential
+):
+    request = rf.get("/")
+    backend = UnenrolledModelBackend()
+
+    authenticated_user = backend.authenticate(
+        request,
+        username=user_with_password.username,
+        password=CORRECT_PASSWORD,
+    )
+
+    assert authenticated_user == user_with_password
+    assert authenticated_user != credential.user


### PR DESCRIPTION
### Motivation

While testing wagtail-mfa for my blog, I realised that I could still log in using my password. This seemed to be an attractive target for a potential attacker, so I thought that a way to disable such logins for user accounts with passkeys enabled while allowing user accounts without passkeys enabled to log in would be useful.

### Solution

An authentication backend `UnenrolledModelBackend` based on `ModelBackend` is provided as a drop-in replacement for `ModelBackend`. This only authenticates users that don't have any confirmed passkeys. So in a typical configuration, one backend handles users that have passkeys (`WebAuthnBackend`) and another handles users that don't have passkeys, rather than both backends handling users that have passkeys, thus registering a passkey blocks attackers from password-based attacks against the user account.

Additionally, `UnenrolledAuthenticationMixin` is provided for developers who would prefer to use their own custom authentication backends.

### Alternatives

An arguably simpler solution for myself would have been to just set an unusable password for my user account. In a situation with many users or non-technical users though, it would be more convenient to have them log in and follow instructions to register a passkey or two, rather than have a developer set an unusable password for them once their passkey registration is confirmed.

### Testing

I have provided unit tests that appear to keep the test coverage at 100%. Furthermore, I have tested the passkey and attempted password login flows myself via wagtail-mfa on my blog's development server.