### PR TITLE
Add `contrib.identify` module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,10 @@ urls.Source = "https://github.com/Stormbase/django-otp-webauthn"
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/django_otp_webauthn/_version.py"
 build.targets.wheel.artifacts = [
+  # Include compiled translations that are gitignored and thus not included by default
+  "src/django_otp_webauthn/**/locale/*/LC_MESSAGES/*.mo",
   # Version is generated during build and gitignored, make sure to include it
   "src/django_otp_webauthn/_version.py",
-  # Include compiled translations that are gitignored and thus not included by default
-  "src/django_otp_webauthn/locale/*/LC_MESSAGES/*.mo",
   # Include built static files that are gitignored and thus not included by default
   "src/django_otp_webauthn/static/django_otp_webauthn/*",
 ]
@@ -105,7 +105,7 @@ build.targets.sdist.artifacts = [
   # Include built static files that are gitignored and thus not included by default
   "src/django_otp_webauthn/static/django_otp_webauthn/*",
   # Include compiled translations that are gitignored and thus not included by default
-  "src/django_otp_webauthn/locale/*/LC_MESSAGES/*.mo",
+  "src/django_otp_webauthn/**/locale/*/LC_MESSAGES/*.mo",
   "sandbox/locale/*/LC_MESSAGES/*.mo",
   # Version is generated during build and gitignored, make sure to include it
   "src/django_otp_webauthn/_version.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ optional-dependencies.docs = [
   "sphinx-copybutton==0.5.2",
   "sphinx-design==0.6.1",
 ]
+optional-dependencies.identify = [
+  "identify-passkey>=1,<2",
+]
 optional-dependencies.playwright = [
   "playwright>=1.49,<2",
   "pytest-playwright>=0.5.2,<1",
@@ -56,6 +59,7 @@ optional-dependencies.testing = [
   # To test functionality with a strict Content Security Policy
   "django-csp>=4,<5",
   "django-debug-toolbar>=6,<7",
+  "django-otp-webauthn[identify]", # The identify tests require the identify-passkey package
   "jsonschema~=4.23",
   # Update as necessary, prevent sudden breakage
   "pytest>9,<10",
@@ -171,9 +175,8 @@ report.exclude_lines = [
   # Don't complain if non-runnable code isn't run:
   "if 0:",
   "if self.debug",
-
   # Nor complain about type checking
-  "if TYPE_CHECKING:",
+  "if TYPE_CHECKING *",
   # Have to re-enable the standard pragma
   "pragma: no cover",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ optional-dependencies.testing = [
   "pytest-mock>=3.14,<4",
   "pytest-randomly>=4,<5",
   "pytest-rerunfailures>=16,<17",
+  "servestatic>=4,<5",             # For testing static file serving using a manifest - not the static file finders
 ]
 urls.Changelog = "https://github.com/Stormbase/django-otp-webauthn/blob/main/CHANGELOG.md"
 urls.Documentation = "https://django-otp-webauthn.readthedocs.io/en/latest/"

--- a/sandbox/admin.py
+++ b/sandbox/admin.py
@@ -1,12 +1,18 @@
+from django.conf import settings
 from django.contrib.admin import AdminSite
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 
 from django_otp_webauthn.admin import WebAuthnCredentialAdmin
-from django_otp_webauthn.utils import get_credential_model
+from django_otp_webauthn.contrib.identify.admin import (
+    AuthenticatorNameMixin,
+    AuthenticatorThumbnailMixin,
+)
+from django_otp_webauthn.utils import get_attestation_model, get_credential_model
 
 User = get_user_model()
 WebAuthnCredential = get_credential_model()
+WebAuthnAttestation = get_attestation_model()
 
 
 class SandboxAdminSite(AdminSite):
@@ -17,6 +23,24 @@ class SandboxAdminSite(AdminSite):
     login_template = "django_admin_login.html"
 
 
+class SandboxCredentialAdmin(
+    AuthenticatorThumbnailMixin, AuthenticatorNameMixin, WebAuthnCredentialAdmin
+):
+    list_display = [
+        "user",
+        "name",
+        "aaguid",
+        "authenticator_name",
+        "credential_icon_thumbnail",
+        "credential_id_sha256",
+        "last_used_at",
+        "created_at",
+    ]
+
+
 admin_site = SandboxAdminSite(name="sandbox_admin")
 admin_site.register(User, UserAdmin)
-admin_site.register(WebAuthnCredential, WebAuthnCredentialAdmin)
+if settings.USE_CONTRIB_IDENTIFY:
+    admin_site.register(WebAuthnCredential, SandboxCredentialAdmin)
+else:
+    admin_site.register(WebAuthnCredential, WebAuthnCredentialAdmin)

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 import dj_database_url
@@ -20,6 +21,8 @@ PROJECT_DIR = Path(__file__).resolve().parent
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+USE_STATIC = os.environ.get("USE_STATIC", "0") == "1"
+USE_CONTRIB_IDENTIFY = os.environ.get("USE_CONTRIB_IDENTIFY", "0") == "1"
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -28,7 +31,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-btdx7xg!bigxep%=qw=r%nvvm4nfpx1gpuh4ci%@#@7m14=hjq"  # noqa: S105 (known false positive)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "1") == "1"
 
 ALLOWED_HOSTS = ["*"]
 
@@ -53,6 +56,12 @@ INSTALLED_APPS = [
     "sandbox",
 ]
 
+if USE_STATIC:
+    INSTALLED_APPS.insert(0, "servestatic")
+
+if USE_CONTRIB_IDENTIFY:
+    INSTALLED_APPS.append("django_otp_webauthn.contrib.identify")
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -65,6 +74,12 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+if USE_STATIC:
+    # Insert after SecurityMiddleware to ensure that static files are served before any security checks
+    pos = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware") + 1
+    MIDDLEWARE.insert(pos, "servestatic.middleware.ServeStaticMiddleware")
+    SERVESTATIC_KEEP_ONLY_HASHED_FILES = True
 
 # SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
@@ -124,6 +139,18 @@ AUTHENTICATION_BACKENDS = [
     "django_otp_webauthn.backends.WebAuthnBackend",
 ]
 
+# Storages
+# https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-STORAGES
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        if not USE_STATIC
+        else "servestatic.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
@@ -142,6 +169,17 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = PROJECT_DIR / "public" / "static"
+
+STATICFILES_FINDERS = [
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+]
+if USE_CONTRIB_IDENTIFY:
+    STATICFILES_FINDERS.append(
+        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
+    )
+
 
 LOGIN_URL = "auth:login"
 LOGIN_REDIRECT_URL = "index"

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -180,6 +180,7 @@ if USE_CONTRIB_IDENTIFY:
         "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
     )
 
+OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "indirect"
 
 LOGIN_URL = "auth:login"
 LOGIN_REDIRECT_URL = "index"

--- a/sandbox/templates/sandbox/index.html
+++ b/sandbox/templates/sandbox/index.html
@@ -41,8 +41,15 @@
                 <button type="submit">{% translate "Logout" %}</button>
             </form>
         </div>
+
+        <h2>{% trans "Registered Passkeys" %}</h2>
+        {% if passkeys %}
+            {% include "sandbox/passkey_table.html" with object_list=passkeys %}
+        {% else %}
+            <p>{% translate "No registered Passkeys." %}</p>
+        {% endif %}
+
     {% else %}
         <a href="{% url "auth:login" %}">Login</a>
     {% endif %}
-
 {% endblock content %}

--- a/sandbox/templates/sandbox/passkey_table.html
+++ b/sandbox/templates/sandbox/passkey_table.html
@@ -1,0 +1,21 @@
+{% load i18n sandbox_tags %}{% spaceless %}
+    {% if object_list %}
+        <table>
+            <thead>
+                <tr>
+                    <th>{% trans "ID" %}</th>
+                    <th>{% trans "Given name" %}</th>
+                    <th><abbr title="{% trans "Authenticator Attestation Globally Unique Identifier, identifier indicating the type (e.g. make and model) of the authenticator." %}">{% trans "AAGUID" %}</abbr></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for obj in object_list %}
+                    <tr>
+                        <td>{{ obj.id }}</td>
+                        <td>{{ obj.name|default:"<i>unnamed</i>" }}</td>
+                        <td>{{ obj.aaguid }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}{% endspaceless %}

--- a/sandbox/templates/sandbox/passkey_table.html
+++ b/sandbox/templates/sandbox/passkey_table.html
@@ -1,11 +1,16 @@
 {% load i18n sandbox_tags %}{% spaceless %}
     {% if object_list %}
         <table>
+            {% contrib_identify_enabled as use_contrib_identify %}
             <thead>
                 <tr>
                     <th>{% trans "ID" %}</th>
                     <th>{% trans "Given name" %}</th>
                     <th><abbr title="{% trans "Authenticator Attestation Globally Unique Identifier, identifier indicating the type (e.g. make and model) of the authenticator." %}">{% trans "AAGUID" %}</abbr></th>
+                    {% if use_contrib_identify %}
+                        <th>{% trans "Authenticator name inferred from AAGUID" %}</th>
+                        <th>{% trans "Authenticator logo" %}</th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -14,6 +19,10 @@
                         <td>{{ obj.id }}</td>
                         <td>{{ obj.name|default:"<i>unnamed</i>" }}</td>
                         <td>{{ obj.aaguid }}</td>
+                        {% if use_contrib_identify %}
+                            <td>{{ obj.inferred_name|default:"<i>unknown</i>" }}</td>
+                            <td>{{ obj.identify.picture_html|default:"<i>no logo</i>" }}</td>
+                        {% endif %}
                     </tr>
                 {% endfor %}
             </tbody>

--- a/sandbox/templatetags/sandbox_tags.py
+++ b/sandbox/templatetags/sandbox_tags.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from django.template import Library
+
+register = Library()
+
+
+@register.simple_tag
+def contrib_identify_enabled():
+    return getattr(settings, "USE_CONTRIB_IDENTIFY", False)

--- a/sandbox/views.py
+++ b/sandbox/views.py
@@ -16,6 +16,11 @@ class IndexView(TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         ctx = super().get_context_data(**kwargs)
         ctx["2fa_verified"] = self.request.user.is_verified()
+        if self.request.user.is_authenticated:
+            passkeys = WebAuthnCredential.objects.filter(user=self.request.user)
+        else:
+            passkeys = WebAuthnCredential.objects.none()
+        ctx["passkeys"] = passkeys
         return ctx
 
 

--- a/src/django_otp_webauthn/admin.py
+++ b/src/django_otp_webauthn/admin.py
@@ -8,6 +8,7 @@ credential_model = app_settings.OTP_WEBAUTHN_CREDENTIAL_MODEL
 
 
 class WebAuthnCredentialAdmin(admin.ModelAdmin):
+    list_display_links = ["aaguid"]
     list_display = [
         "user",
         "name",
@@ -66,9 +67,7 @@ class WebAuthnCredentialAdmin(admin.ModelAdmin):
             ),
             (
                 _("Meta"),
-                {
-                    "fields": ["last_used_at", "created_at"],
-                },
+                {"fields": ["last_used_at", "created_at"]},
             ),
             (
                 _("WebAuthn credential data"),

--- a/src/django_otp_webauthn/apps.py
+++ b/src/django_otp_webauthn/apps.py
@@ -11,6 +11,9 @@ class OtpWebauthnConfig(AppConfig):
     verbose_name = _("OTP WebAuthn")
 
     def ready(self):
+        register(
+            checks.check_settings_attestation_conveyance_preference, Tags.compatibility
+        )
         register(checks.check_settings_supported_cose_algorithms, Tags.security)
         register(checks.check_settings_dangerous_session_backend_used, Tags.security)
         register(checks.check_settings_allowed_origins_missing, Tags.compatibility)

--- a/src/django_otp_webauthn/checks.py
+++ b/src/django_otp_webauthn/checks.py
@@ -13,6 +13,7 @@ ERR_ALLOWED_ORIGINS_MALFORMED = "otp_webauthn.E031"
 ERR_DANGEROUS_SESSION_BACKEND = "otp_webauthn.E040"
 ERR_ATTESTATION_MISSING_CREDENTIAL_FIELD = "otp_webauthn.E050"
 ERR_RP_RELATED_ORIGINS_MALFORMED = "otp_webauthn.E060"
+ERR_FAULTY_CONVEYANCE_PREFERENCE = "otp_webauthn.E070"
 
 
 def check_settings_relying_party(app_configs, **kwargs):
@@ -41,6 +42,23 @@ def check_settings_relying_party(app_configs, **kwargs):
                 hint="Set the OTP_WEBAUTHN_RP_NAME setting to a human-readable name for the relying party, like: 'Acme Corp.'.",
                 obj=None,
                 id=ERR_NO_RP_NAME,
+            )
+        )
+
+    return errors
+
+
+def check_settings_attestation_conveyance_preference(app_configs, **kwargs):
+    errors = []
+    conveyance_preference = app_settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE
+
+    if conveyance_preference not in ["direct", "indirect", "enterprise", "none"]:
+        errors.append(
+            Error(
+                f"Invalid attestation conveyance preference: {conveyance_preference!r}",
+                hint="Set the OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE setting to one of 'direct', 'indirect', 'enterprise', or 'none'.",
+                obj=None,
+                id=ERR_FAULTY_CONVEYANCE_PREFERENCE,
             )
         )
 

--- a/src/django_otp_webauthn/contrib/identify/__init__.py
+++ b/src/django_otp_webauthn/contrib/identify/__init__.py
@@ -1,5 +1,8 @@
 from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
+from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor, PasskeyIcon
 
 __all__ = [
     "PasskeyIconsFinder",
+    "PasskeyDescriptor",
+    "PasskeyIcon",
 ]

--- a/src/django_otp_webauthn/contrib/identify/__init__.py
+++ b/src/django_otp_webauthn/contrib/identify/__init__.py
@@ -1,8 +1,46 @@
+from typing import TYPE_CHECKING
+
 from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
 from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor, PasskeyIcon
 
+if TYPE_CHECKING:
+    from identify_passkey import PasskeyDescriptor as _InternalPasskeyDescriptor
+
 __all__ = [
+    "identify_passkey",
     "PasskeyIconsFinder",
     "PasskeyDescriptor",
     "PasskeyIcon",
 ]
+
+
+def _identify_passkey() -> "_InternalPasskeyDescriptor | None":
+    from identify_passkey import identify_passkey as _id_passkey
+
+    return _id_passkey
+
+
+def identify_passkey(aaguid: str) -> PasskeyDescriptor | None:
+    """
+    Identify the passkey type based on the credential's AAGUID.
+
+    Args:
+        aaguid (str): The AAGUID of the WebAuthn credential.
+
+    Returns:
+        :class:`PasskeyDescriptor` | None: The identified passkey descriptor or None if not found.
+    """
+    passkey_descriptor = _identify_passkey()(aaguid)
+    if not passkey_descriptor:
+        return None
+
+    return PasskeyDescriptor(
+        aaguid=passkey_descriptor.aaguid,
+        name=passkey_descriptor.name,
+        icon_light=PasskeyIcon(ref=passkey_descriptor.icon_light)
+        if passkey_descriptor.icon_light
+        else None,
+        icon_dark=PasskeyIcon(ref=passkey_descriptor.icon_dark)
+        if passkey_descriptor.icon_dark
+        else None,
+    )

--- a/src/django_otp_webauthn/contrib/identify/__init__.py
+++ b/src/django_otp_webauthn/contrib/identify/__init__.py
@@ -1,0 +1,5 @@
+from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
+
+__all__ = [
+    "PasskeyIconsFinder",
+]

--- a/src/django_otp_webauthn/contrib/identify/__init__.py
+++ b/src/django_otp_webauthn/contrib/identify/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
@@ -14,7 +15,7 @@ __all__ = [
 ]
 
 
-def _identify_passkey() -> "_InternalPasskeyDescriptor | None":
+def _identify_passkey() -> "Callable[[str], _InternalPasskeyDescriptor | None]":
     from identify_passkey import identify_passkey as _id_passkey
 
     return _id_passkey

--- a/src/django_otp_webauthn/contrib/identify/admin.py
+++ b/src/django_otp_webauthn/contrib/identify/admin.py
@@ -33,12 +33,12 @@ class AuthenticatorThumbnailMixin:
 
         Returns:
             :class:`~django.utils.safestring.SafeString`: An HTML ``<picture>``
-            tag with the credential icon thumbnail or a placeholder if not available.
+            tag with the credential icon thumbnail or nothing if not available.
         """
 
         passkey_descriptor = _identify()(obj.aaguid)
         if not passkey_descriptor:
-            return ""
+            return SafeString("")  # No icon for unknown AAGUID
 
         return passkey_descriptor.picture_html(
             picture_attrs={"class": "credential-icon-thumbnail"}

--- a/src/django_otp_webauthn/contrib/identify/admin.py
+++ b/src/django_otp_webauthn/contrib/identify/admin.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING
+
+from django.contrib import admin
+from django.utils.safestring import SafeString
+from django.utils.translation import gettext_lazy as _
+
+if TYPE_CHECKING:
+    from django_otp_webauthn.models import AbstractWebAuthnCredential
+
+
+def _identify():
+    from django_otp_webauthn.contrib.identify import identify_passkey
+
+    return identify_passkey
+
+
+class AuthenticatorThumbnailMixin:
+    """
+    Mixin for Django admin classes to display a thumbnail of the WebAuthn credential icon.
+
+    Usage:
+        class MyAdmin(AuthenticatorThumbnailMixin, admin.ModelAdmin):
+            list_display = ['credential_icon_thumbnail', ...]
+    """
+
+    @admin.display(description=_("Authenticator Icon"))
+    def credential_icon_thumbnail(self, obj) -> SafeString:
+        """
+        Returns a prefers-color-scheme aware HTML ``<picture>`` tag for the credential icon thumbnail.
+
+        Args:
+            obj: The WebAuthn credential object.
+
+        Returns:
+            :class:`~django.utils.safestring.SafeString`: An HTML ``<picture>``
+            tag with the credential icon thumbnail or a placeholder if not available.
+        """
+
+        passkey_descriptor = _identify()(obj.aaguid)
+        if not passkey_descriptor:
+            return ""
+
+        return passkey_descriptor.picture_html(
+            picture_attrs={"class": "credential-icon-thumbnail"}
+        )
+
+
+class AuthenticatorNameMixin:
+    """
+    Mixin for Django admin classes to display the authenticator name based on the AAGUID.
+
+    Usage:
+        class MyAdmin(AuthenticatorNameMixin, admin.ModelAdmin):
+            list_display = ['authenticator_name', ...]
+    """
+
+    @admin.display(description=_("Authenticator Name (inferred)"))
+    def authenticator_name(self, obj: "AbstractWebAuthnCredential") -> str:
+        """
+        Returns the inferred authenticator name based on the AAGUID.
+
+        Args:
+            obj: The WebAuthn credential object.
+
+        Returns:
+            str: The inferred authenticator name or a placeholder if not available.
+        """
+        passkey_descriptor = _identify()(obj.aaguid)
+        if not passkey_descriptor:
+            return _("Unknown Authenticator")
+
+        return passkey_descriptor.name

--- a/src/django_otp_webauthn/contrib/identify/apps.py
+++ b/src/django_otp_webauthn/contrib/identify/apps.py
@@ -1,0 +1,16 @@
+from django.apps import AppConfig
+from django.core.checks import Tags, register
+from django.utils.translation import gettext_lazy as _
+
+from django_otp_webauthn.contrib.identify import checks
+
+
+class OtpWebauthnIdentifyConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "django_otp_webauthn.contrib.identify"
+    verbose_name = _("OTP WebAuthn Identify")
+
+    def ready(self):
+        # Register system checks
+        register(checks.check_identify_passkey_package_installed, Tags.compatibility)
+        register(checks.check_passkey_icon_finder_enabled, Tags.compatibility)

--- a/src/django_otp_webauthn/contrib/identify/checks.py
+++ b/src/django_otp_webauthn/contrib/identify/checks.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.checks import Error
 from django.utils.module_loading import import_string
 
+from django_otp_webauthn import utils as package_utils
 from django_otp_webauthn.contrib.identify import utils
 from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
 
@@ -10,6 +11,8 @@ ERR_IDENTIFY_PASSKEY_PACKAGE_NOT_INSTALLED = "otp_webauthn_identify.E001"
 
 def check_identify_passkey_package_installed(app_configs, **kwargs):
     """Check if the 'identify_passkey' package is installed."""
+    if not package_utils.is_contrib_identify_module_enabled():
+        return []
 
     errors = []
     if not utils.is_identify_passkey_package_installed():
@@ -26,6 +29,8 @@ def check_identify_passkey_package_installed(app_configs, **kwargs):
 
 def check_passkey_icon_finder_enabled(app_configs, **kwargs):
     """Check if ``django_otp_webauthn.contrib.identify.PasskeyIconsFinder`` (or a subclass) is enabled."""
+    if not package_utils.is_contrib_identify_module_enabled():
+        return []
 
     errors = []
     # Look for subclasses of PasskeyIconsFinder

--- a/src/django_otp_webauthn/contrib/identify/checks.py
+++ b/src/django_otp_webauthn/contrib/identify/checks.py
@@ -1,0 +1,47 @@
+from django.conf import settings
+from django.core.checks import Error
+from django.utils.module_loading import import_string
+
+from django_otp_webauthn.contrib.identify import utils
+from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
+
+ERR_IDENTIFY_PASSKEY_PACKAGE_NOT_INSTALLED = "otp_webauthn_identify.E001"
+
+
+def check_identify_passkey_package_installed(app_configs, **kwargs):
+    """Check if the 'identify_passkey' package is installed."""
+
+    errors = []
+    if not utils.is_identify_passkey_package_installed():
+        errors.append(
+            Error(
+                "The 'identify_passkey' package is not installed.",
+                hint="Did you install django-otp-webauthn with the 'identify' extra? Try: pip install django-otp-webauthn[identify]",
+                obj=None,
+                id=ERR_IDENTIFY_PASSKEY_PACKAGE_NOT_INSTALLED,
+            )
+        )
+    return errors
+
+
+def check_passkey_icon_finder_enabled(app_configs, **kwargs):
+    """Check if ``django_otp_webauthn.contrib.identify.PasskeyIconsFinder`` (or a subclass) is enabled."""
+
+    errors = []
+    # Look for subclasses of PasskeyIconsFinder
+    for finder in settings.STATICFILES_FINDERS:
+        # No need to handle ModuleNotFoundError, this check won't even run if
+        # Django can't lookup the finder class when resolving settings
+        finder_class = import_string(finder)
+        if issubclass(finder_class, PasskeyIconsFinder):
+            break
+    else:
+        errors.append(
+            Error(
+                "Static file finder 'django_otp_webauthn.contrib.identify.PasskeyIconsFinder' is not enabled.",
+                hint="Add 'django_otp_webauthn.contrib.identify.PasskeyIconsFinder' to your STATICFILES_FINDERS setting.",
+                obj=None,
+                id="otp_webauthn_identify.E002",
+            )
+        )
+    return errors

--- a/src/django_otp_webauthn/contrib/identify/finders.py
+++ b/src/django_otp_webauthn/contrib/identify/finders.py
@@ -1,0 +1,34 @@
+from importlib.util import find_spec
+from pathlib import Path
+
+from django.contrib.staticfiles.finders import FileSystemFinder
+from django.core.files.storage import FileSystemStorage
+
+PACKAGE = "identify_passkey.icons"
+STATIC_PATH_PREFIX = "django_otp_webauthn/passkey-icons"
+
+
+class PasskeyIconsFinder(FileSystemFinder):
+    """A staticfiles finder that finds any icons under the ``identify_passkey.icons``
+    package and collects them under the ``django_otp_webauthn/passkey-icons``
+    static file prefix.
+
+    This allows icons from the ``identify-passkey`` package to be served as
+    static files in a Django project.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # No need to check for import errors, there is a system check in place
+        # that will warn if the package is not installed.
+        spec = find_spec(PACKAGE)
+        self.locations = [
+            (STATIC_PATH_PREFIX, Path(location))
+            for location in spec.submodule_search_locations
+        ]
+
+        self.storages = {}
+
+        for prefix, root in self.locations:
+            storage = FileSystemStorage(location=root)
+            storage.prefix = prefix
+            self.storages[root] = storage

--- a/src/django_otp_webauthn/contrib/identify/finders.py
+++ b/src/django_otp_webauthn/contrib/identify/finders.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from django.contrib.staticfiles.finders import FileSystemFinder
 from django.core.files.storage import FileSystemStorage
 
+from django_otp_webauthn.contrib.identify import utils
+
 PACKAGE = "identify_passkey.icons"
 STATIC_PATH_PREFIX = "django_otp_webauthn/passkey-icons"
 
@@ -18,13 +20,14 @@ class PasskeyIconsFinder(FileSystemFinder):
     """
 
     def __init__(self, *args, **kwargs):
-        # No need to check for import errors, there is a system check in place
-        # that will warn if the package is not installed.
-        spec = find_spec(PACKAGE)
-        self.locations = [
-            (STATIC_PATH_PREFIX, Path(location))
-            for location in spec.submodule_search_locations
-        ]
+        if not utils.is_identify_passkey_package_installed():
+            self.locations = []
+        else:
+            spec = find_spec(PACKAGE)
+            self.locations = [
+                (STATIC_PATH_PREFIX, Path(location))
+                for location in spec.submodule_search_locations
+            ]
 
         self.storages = {}
 

--- a/src/django_otp_webauthn/contrib/identify/locale/de/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/contrib/identify/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-24 09:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:14
+msgid "Authenticator Icon"
+msgstr "Authenticator-Icon"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:41
+msgid "Authenticator Name (inferred)"
+msgstr "Authenticator-Name (abgeleitet)"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:54
+msgid "Unknown Authenticator"
+msgstr "Unbekannter Authenticator"
+
+#: src/django_otp_webauthn/contrib/identify/apps.py:11
+msgid "OTP WebAuthn Identify"
+msgstr "OTP WebAuthn Identifikation"

--- a/src/django_otp_webauthn/contrib/identify/locale/es/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/contrib/identify/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-24 09:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:14
+msgid "Authenticator Icon"
+msgstr "Icono del autenticador"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:41
+msgid "Authenticator Name (inferred)"
+msgstr "Nombre del autenticador (inferido)"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:54
+msgid "Unknown Authenticator"
+msgstr "Autenticador desconocido"
+
+#: src/django_otp_webauthn/contrib/identify/apps.py:11
+msgid "OTP WebAuthn Identify"
+msgstr "OTP WebAuthn Identificación"

--- a/src/django_otp_webauthn/contrib/identify/locale/it/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/contrib/identify/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-24 09:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:14
+msgid "Authenticator Icon"
+msgstr "Icona dell'autenticatore"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:41
+msgid "Authenticator Name (inferred)"
+msgstr "Nome dell'autenticatore (dedotto)"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:54
+msgid "Unknown Authenticator"
+msgstr "Autenticatore sconosciuto"
+
+#: src/django_otp_webauthn/contrib/identify/apps.py:11
+msgid "OTP WebAuthn Identify"
+msgstr "OTP WebAuthn Identificazione"

--- a/src/django_otp_webauthn/contrib/identify/locale/nl/LC_MESSAGES/django.po
+++ b/src/django_otp_webauthn/contrib/identify/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-24 09:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:14
+msgid "Authenticator Icon"
+msgstr "Authenticatorpictogram"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:41
+msgid "Authenticator Name (inferred)"
+msgstr "Authenticatornaam (afgeleid)"
+
+#: src/django_otp_webauthn/contrib/identify/admin.py:54
+msgid "Unknown Authenticator"
+msgstr "Onbekende Authenticator"
+
+#: src/django_otp_webauthn/contrib/identify/apps.py:11
+msgid "OTP WebAuthn Identify"
+msgstr "OTP WebAuthn Identificatie"

--- a/src/django_otp_webauthn/contrib/identify/templates/django_otp_webauthn/contrib/identify/passkey_icon_picture.html
+++ b/src/django_otp_webauthn/contrib/identify/templates/django_otp_webauthn/contrib/identify/passkey_icon_picture.html
@@ -1,0 +1,13 @@
+{% spaceless %}{% with fallback_icon_url=icon_light_url|default:icon_dark_url %}
+    <picture{{ picture_attrs|default:"" }}>
+    {% comment %} Only include source elements if the light and dark icons are different {% endcomment %}
+        {% if icon_light_url != icon_dark_url %}
+            {% if icon_light_url %}
+                <source srcset="{{ icon_light_url }}" media="(prefers-color-scheme: light)" />
+            {% endif %} {% if icon_dark_url %}
+                <source srcset="{{ icon_dark_url }}" media="(prefers-color-scheme: dark)" />
+            {% endif %}
+        {% endif %}
+        <img{{ img_attrs|default:"" }} src="{{ fallback_icon_url }}"/>
+    </picture>
+{% endwith %}{% endspaceless %}

--- a/src/django_otp_webauthn/contrib/identify/types.py
+++ b/src/django_otp_webauthn/contrib/identify/types.py
@@ -92,6 +92,7 @@ class PasskeyDescriptor(NamedTuple):
         if picture_attrs is None:
             picture_attrs = {}
 
+        img_attrs = {} if img_attrs is None else img_attrs.copy()
         img_attrs.setdefault("width", "32")
         img_attrs.setdefault("alt", escape(self.name))
 

--- a/src/django_otp_webauthn/contrib/identify/types.py
+++ b/src/django_otp_webauthn/contrib/identify/types.py
@@ -97,7 +97,7 @@ class PasskeyDescriptor(NamedTuple):
         img_attrs.setdefault("alt", escape(self.name))
 
         if self.icon_light is None and self.icon_dark is None:
-            return ""
+            return SafeString("")
 
         icon_light_url = None
         icon_dark_url = None

--- a/src/django_otp_webauthn/contrib/identify/types.py
+++ b/src/django_otp_webauthn/contrib/identify/types.py
@@ -17,7 +17,7 @@ class PasskeyIcon(NamedTuple):
 
     @property
     def static_url(self) -> str:
-        """Django static file url to the icon file, using your configured staticfiles storage. Example: ``/static/django_otp_webauthn/.png``"""
+        """Django static file url to the icon file, using your configured staticfiles storage. Example: ``/static/django_otp_webauthn/passkey-icons/apple-passwords-icon.svg``"""
         return staticfiles_storage.url(f"{STATIC_PATH_PREFIX}/{self.ref.path.name}")
 
     @property

--- a/src/django_otp_webauthn/contrib/identify/types.py
+++ b/src/django_otp_webauthn/contrib/identify/types.py
@@ -1,0 +1,117 @@
+from typing import TYPE_CHECKING, Literal, NamedTuple
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.forms.utils import flatatt
+from django.template.loader import render_to_string
+from django.utils.html import escape
+from django.utils.safestring import SafeString
+
+from .finders import STATIC_PATH_PREFIX
+
+if TYPE_CHECKING:
+    from identify_passkey import PasskeyIcon as _InternalPasskeyIcon
+
+
+class PasskeyIcon(NamedTuple):
+    ref: "_InternalPasskeyIcon"
+
+    @property
+    def static_url(self) -> str:
+        """Django static file url to the icon file, using your configured staticfiles storage. Example: ``/static/django_otp_webauthn/.png``"""
+        return staticfiles_storage.url(f"{STATIC_PATH_PREFIX}/{self.ref.path.name}")
+
+    @property
+    def mime_type(self) -> str:
+        """The MIME type of the icon file. Example: ``image/png`` or ``image/svg+xml``"""
+        return self.ref.mime_type
+
+    @property
+    def theme(self) -> Literal["light", "dark"]:
+        """If the icon is meant for light or dark themes. Due to poor upstream data hygiene, the same icon may be used for both themes."""
+        return self.ref.theme
+
+    @property
+    def data_uri(self) -> str:
+        """Data URI version of the icon. Example: ``data:image/png;base64,...``"""
+        return self.ref.data_uri
+
+
+class PasskeyDescriptor(NamedTuple):
+    aaguid: str
+    """The AAGUID of the passkey's authenticator. This is an identifier for the authenticator model that created the credential."""
+    name: str
+    """Human-readable name for the authenticator that created the credential."""
+    icon_light: PasskeyIcon | None = None
+    """Icon for light themes. May be None if no icon is available."""
+    icon_dark: PasskeyIcon | None = None
+    """Icon for dark themes. May be None if no icon is available."""
+
+    def icon_data_uri(self, theme: Literal["light", "dark"] = "light") -> str | None:
+        """Returns a data URI for the icon. Like ``data:image/png;base64,...`` If no icon is available, returns None.
+
+        You can specify the ``theme`` argument ("light" or "dark") to get the corresponding icon.
+        Due to poor upstream data hygiene, the same icon may be used for both themes and not match the requested theme.
+        """
+        if theme not in ("light", "dark"):
+            raise ValueError(f"Invalid theme: {theme}. Must be 'light' or 'dark'.")
+
+        if theme == "light" and self.icon_light is not None:
+            return self.icon_light.data_uri
+        if theme == "dark" and self.icon_dark is not None:
+            return self.icon_dark.data_uri
+        return None
+
+    @property
+    def has_icon(self) -> bool:
+        """True if the passkey descriptor has at least one icon (light or dark)."""
+        return self.icon_light is not None or self.icon_dark is not None
+
+    def picture_html(
+        self,
+        img_attrs: dict[str, str] | None = None,
+        picture_attrs: dict[str, str] | None = None,
+    ) -> SafeString:
+        """Returns a `prefers-color-scheme <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme>`_
+        aware HTML `<picture> <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture>`_
+        tag for the icon, or an empty string if no icon is available.
+
+        Args:
+            img_attrs (dict[str, str] | None): Optional HTML attributes to include on the <img>. Defaults to ``{"width": "32", "alt": self.name}``.
+
+            picture_attrs (dict[str, str] | None): Optional HTML attributes to include on the <picture> tag. Defaults to ``{}``.
+        Returns:
+            :class:`SafeString <django.utils.safestring.SafeString>`: The HTML <picture> tag as a SafeString, or empty string if no icon is available.
+
+        Warning:
+            The attributes are passed through :func:`django.forms.utils.flatatt`, which assumes keys are already XML escaped.
+            You are responsible for ensuring that the attributes are safe – don't allow user controllable data to be
+            passed in here without proper escaping.
+        """
+        if img_attrs is None:
+            img_attrs = {}
+        if picture_attrs is None:
+            picture_attrs = {}
+
+        img_attrs.setdefault("width", "32")
+        img_attrs.setdefault("alt", escape(self.name))
+
+        if self.icon_light is None and self.icon_dark is None:
+            return ""
+
+        icon_light_url = None
+        icon_dark_url = None
+        if self.icon_light:
+            icon_light_url = self.icon_light.static_url
+        if self.icon_dark:
+            icon_dark_url = self.icon_dark.static_url
+
+        return render_to_string(
+            "django_otp_webauthn/contrib/identify/passkey_icon_picture.html",
+            {
+                "name": escape(self.name),
+                "icon_light_url": icon_light_url,
+                "icon_dark_url": icon_dark_url,
+                "picture_attrs": flatatt(picture_attrs),
+                "img_attrs": flatatt(img_attrs),
+            },
+        )

--- a/src/django_otp_webauthn/contrib/identify/types.py
+++ b/src/django_otp_webauthn/contrib/identify/types.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Literal, NamedTuple
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
-from django.utils.html import escape
 from django.utils.safestring import SafeString
 
 from .finders import STATIC_PATH_PREFIX
@@ -94,7 +93,7 @@ class PasskeyDescriptor(NamedTuple):
 
         img_attrs = {} if img_attrs is None else img_attrs.copy()
         img_attrs.setdefault("width", "32")
-        img_attrs.setdefault("alt", escape(self.name))
+        img_attrs.setdefault("alt", self.name)
 
         if self.icon_light is None and self.icon_dark is None:
             return SafeString("")
@@ -109,7 +108,7 @@ class PasskeyDescriptor(NamedTuple):
         return render_to_string(
             "django_otp_webauthn/contrib/identify/passkey_icon_picture.html",
             {
-                "name": escape(self.name),
+                "name": self.name,
                 "icon_light_url": icon_light_url,
                 "icon_dark_url": icon_dark_url,
                 "picture_attrs": flatatt(picture_attrs),

--- a/src/django_otp_webauthn/contrib/identify/utils.py
+++ b/src/django_otp_webauthn/contrib/identify/utils.py
@@ -1,0 +1,9 @@
+from importlib import util
+
+
+def is_identify_passkey_package_installed() -> bool:
+    """Check if the 'identify_passkey' package is installed."""
+    try:
+        return util.find_spec("identify_passkey") is not None
+    except ModuleNotFoundError:
+        return False

--- a/src/django_otp_webauthn/helpers.py
+++ b/src/django_otp_webauthn/helpers.py
@@ -169,7 +169,9 @@ class WebAuthnHelper:
         https://www.w3.org/TR/webauthn-2/#sctn-attestation -
         https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html
         """
-        return AttestationConveyancePreference.NONE
+        return AttestationConveyancePreference(
+            app_settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE
+        )
 
     def get_authenticator_attachment_preference(
         self,

--- a/src/django_otp_webauthn/models.py
+++ b/src/django_otp_webauthn/models.py
@@ -29,7 +29,7 @@ from django_otp_webauthn.utils import (
 
 User = get_user_model()
 
-if TYPE_CHECKING and is_contrib_identify_module_enabled():
+if TYPE_CHECKING:
     from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor
 
 

--- a/src/django_otp_webauthn/models.py
+++ b/src/django_otp_webauthn/models.py
@@ -1,12 +1,13 @@
 import hashlib
 from secrets import token_bytes
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.core import checks
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
@@ -21,13 +22,26 @@ from webauthn.helpers.structs import (
 
 from django_otp_webauthn import checks as otp_webauthn_checks
 from django_otp_webauthn.settings import app_settings
-from django_otp_webauthn.utils import get_credential_model_string
+from django_otp_webauthn.utils import (
+    get_credential_model_string,
+    is_contrib_identify_module_enabled,
+)
 
 User = get_user_model()
 
+if TYPE_CHECKING and is_contrib_identify_module_enabled():
+    from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor
+
+
+def _identify_passkey():
+    # To avoid importing django_otp_webauthn.contrib.identify at the top level (when not enabled)
+    import django_otp_webauthn.contrib.identify
+
+    return django_otp_webauthn.contrib.identify.identify_passkey
+
 
 def as_credential_descriptors(
-    queryset: QuerySet["AbstractWebAuthnCredential"],
+    queryset: models.QuerySet["AbstractWebAuthnCredential"],
 ) -> list[PublicKeyCredentialDescriptor]:
     descriptors = []
     for id, raw_transports in queryset.values_list("credential_id", "transports"):
@@ -146,6 +160,23 @@ class AbstractWebAuthnCredential(TimestampMixin, Device):
         ]
         verbose_name = _("WebAuthn credential")
         verbose_name_plural = _("WebAuthn credentials")
+
+    def __str__(self):
+        if not self.name and self.inferred_name:
+            return f"{self.inferred_name} ({self.user})"
+        return super().__str__()
+
+    @property
+    def inferred_name(self):
+        """Automatically inferred name for this device. Uses ``django_otp_webauthn.contrib.identify``
+        to identify the device based on its AAGUID.
+
+        Will return None if the device cannot be identified (for example if the
+        AAGUID is zeroed out or not known).
+        """
+        if is_contrib_identify_module_enabled() and (ident := self.identify()):
+            return ident.name
+        return None
 
     objects = WebAuthnCredentialManager.from_queryset(WebAuthnCredentialQuerySet)()
 
@@ -332,6 +363,13 @@ class AbstractWebAuthnCredential(TimestampMixin, Device):
             )
         super().save(*args, **kwargs)
 
+    def identify(self) -> "PasskeyDescriptor | None":
+        if not is_contrib_identify_module_enabled():
+            raise ImproperlyConfigured(
+                "django_otp_webauthn.contrib.identify is not installed. Add it to your INSTALLED_APPS to use the identify feature."
+            )
+        return _identify_passkey()(self.aaguid)
+
     @classmethod
     def get_by_credential_id(cls, credential_id: bytes) -> "WebAuthnCredential":
         """Return a WebAuthnCredential instance by its credential id.
@@ -411,7 +449,7 @@ class WebAuthnUserHandle(models.Model):
     have a credential for a given user. In practice this is used to avoid having
     multiple credentials for the same user on the same authenticator.
 
-    This models follows the recommendation [^2] in the WebAuthn Level 3
+    This model follows the recommendation [^2] in the WebAuthn Level 3
     specification to let the user handle be 64 random bytes, stored with the
     user account.
 

--- a/src/django_otp_webauthn/settings.py
+++ b/src/django_otp_webauthn/settings.py
@@ -2,6 +2,7 @@
 # https://overtag.dk/v2/blog/a-settings-pattern-for-reusable-django-apps/
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
@@ -104,6 +105,29 @@ class AppSettings:
 
     Take care to keep this value reasonable. You ought to follow WCAG 2.2
     accessibility guidelines regarding timeouts. See https://www.w3.org/TR/WCAG22/#enough-time.
+    """
+
+    OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE: Literal[
+        "direct", "indirect", "enterprise", "none"
+    ] = "none"
+    """.. versionadded:: v0.11.0
+
+    Controls whether we, the relying party, want to receive :term:`attestation`
+    information from the :term:`authenticator` when registering a new credential.
+    Supported values are: ``direct``, ``indirect``, ``enterprise``, or ``none``.
+
+    Attestation conveys cryptographically-verifiable proof information about the
+    authenticator, such as its manufacturer and model. The purpose is to prove
+    that the authenticator really comes from the claimed manufacturer.
+
+    :admonition: Setting this to a value like ``indirect`` or ``direct`` may cause browsers
+        to prompt the user that the website requests to read their device's make and
+        model information, which can be rejected in which case no attestation
+        information will be sent. Registration will still succeed, but no
+        attestation information will be available to you.
+
+    For more information about attestation in general, see the `MDN documentation <https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Attestation_and_Assertion#attestation>`_
+    For more information about the specific values, see the `WebAuthn specification <https://www.w3.org/TR/webauthn-3/#enumdef-attestationconveyancepreference>`_
     """
 
     def __getattribute__(self, __name: str):

--- a/src/django_otp_webauthn/utils.py
+++ b/src/django_otp_webauthn/utils.py
@@ -92,6 +92,10 @@ class rewrite_exceptions:
         return False
 
 
+def is_contrib_identify_module_enabled() -> bool:
+    return apps.is_installed("django_otp_webauthn.contrib.identify")
+
+
 def get_exempt_urls() -> list:
     """Returns the list of urls that should be allowed without 2FA verification."""
     return [

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,6 +10,8 @@ from django_otp_webauthn.models import (
 
 from .fuzzy import FuzzyBytes
 
+APPLE_AAGUID = "fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+
 
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
@@ -29,7 +31,10 @@ class WebAuthnCredentialFactory(factory.django.DjangoModelFactory):
 
     class Params:
         attested = factory.Trait(
-            attestation=factory.SubFactory("tests.factories.WebAuthnAttestationFactory")
+            attestation=factory.SubFactory(
+                "tests.factories.WebAuthnAttestationFactory"
+            ),
+            aaguid=APPLE_AAGUID,
         )
 
     @factory.lazy_attribute

--- a/tests/testapp/finders.py
+++ b/tests/testapp/finders.py
@@ -1,0 +1,5 @@
+from django_otp_webauthn.contrib.identify.finders import PasskeyIconsFinder
+
+
+class CustomPasskeyIconsFinder(PasskeyIconsFinder):
+    """Custom static file finder for Passkey icons, used to check if the system check can detect subclasses of PasskeyIconsFinder."""

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -4,10 +4,21 @@
 #  $ DJANGO_SETTINGS_MODULE=tests.testapp.settings python manage.py
 
 from sandbox.settings import *  # noqa: F403
+from sandbox.settings import INSTALLED_APPS, STATICFILES_FINDERS
 
-INSTALLED_APPS += [  # noqa: F405
+INSTALLED_APPS += [
     "tests.testapp",
 ]
+
+# Remove the identify app and PasskeyIconsFinder from STATICFILES_FINDERS for testing purposes
+INSTALLED_APPS = tuple(
+    app for app in INSTALLED_APPS if app != "django_otp_webauthn.contrib.identify"
+)
+STATICFILES_FINDERS = tuple(
+    finder
+    for finder in STATICFILES_FINDERS
+    if finder != "django_otp_webauthn.contrib.identify.PasskeyIconsFinder"
+)
 
 OTP_WEBAUTHN_RP_ID = "example.com"
 OTP_WEBAUTHN_RP_NAME = "Example Corp."

--- a/tests/unit/contrib/identify/conftest.py
+++ b/tests/unit/contrib/identify/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def enable_contrib_identify_app(settings):
+    """Enable the 'django_otp_webauthn.contrib.identify' app for testing."""
+    settings.INSTALLED_APPS += ("django_otp_webauthn.contrib.identify",)
+    settings.STATICFILES_FINDERS += (
+        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
+    )

--- a/tests/unit/contrib/identify/conftest.py
+++ b/tests/unit/contrib/identify/conftest.py
@@ -1,10 +1,23 @@
+import django.template
 import pytest
+from django.apps import apps
+from django.template.utils import EngineHandler
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(autouse=True)
 def enable_contrib_identify_app(settings):
     """Enable the 'django_otp_webauthn.contrib.identify' app for testing."""
-    settings.INSTALLED_APPS += ("django_otp_webauthn.contrib.identify",)
-    settings.STATICFILES_FINDERS += (
-        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
-    )
+    if "django_otp_webauthn.contrib.identify" not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS += ("django_otp_webauthn.contrib.identify",)
+    if (
+        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder"
+        not in settings.STATICFILES_FINDERS
+    ):
+        settings.STATICFILES_FINDERS += (
+            "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
+        )
+    apps.set_installed_apps(settings.INSTALLED_APPS)
+    django.template.engines = EngineHandler()
+    yield
+    apps.unset_installed_apps()
+    django.template.engines = EngineHandler()

--- a/tests/unit/contrib/identify/test_admin.py
+++ b/tests/unit/contrib/identify/test_admin.py
@@ -1,0 +1,58 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.contrib.admin import AdminSite
+
+from django_otp_webauthn.admin import WebAuthnCredentialAdmin
+from django_otp_webauthn.contrib.identify.admin import (
+    AuthenticatorNameMixin,
+    AuthenticatorThumbnailMixin,
+)
+from django_otp_webauthn.models import WebAuthnCredential
+from tests.factories import APPLE_AAGUID
+
+
+class AdminWithMixins(
+    AuthenticatorNameMixin, AuthenticatorThumbnailMixin, WebAuthnCredentialAdmin
+):
+    list_display = WebAuthnCredentialAdmin.list_display + [
+        "authenticator_name",
+        "credential_icon_thumbnail",
+    ]
+
+
+@pytest.mark.django_db
+def test_webauthn_credential_modeladmin_mixins__apple(credential):
+    """Verify that the admin mixins works correctly for Apple credentials."""
+
+    credential.aaguid = APPLE_AAGUID
+    credential.save()
+    model_admin = AdminWithMixins(WebAuthnCredential, AdminSite())
+
+    # Test authenticator_name
+    name = model_admin.authenticator_name(credential)
+    assert name == "Apple Passwords"
+
+    # Test authenticator_thumbnail
+    thumbnail_html = model_admin.credential_icon_thumbnail(credential)
+    soup = BeautifulSoup(thumbnail_html, "html.parser")
+    img_tag = soup.find("img")
+    picture_tag = soup.find("picture")
+    assert picture_tag is not None
+    assert "credential-icon-thumbnail" in picture_tag["class"]
+
+    assert img_tag is not None
+    assert img_tag["src"].startswith("/static/django_otp_webauthn/")
+    assert img_tag["alt"] == "Apple Passwords"
+    assert img_tag["width"] == "32"
+
+
+@pytest.mark.django_db
+def test_webauthn_credential_modeladmin_mixins__unknown(credential):
+    """Verify that the admin mixins works correctly for unknown credentials."""
+    credential.aaguid = "00000000-0000-0000-0000-000000000000"  # Unknown AAGUID
+    credential.save()
+    model_admin = AdminWithMixins(WebAuthnCredential, AdminSite())
+    thumbnail_html = model_admin.credential_icon_thumbnail(credential)
+    assert thumbnail_html == ""  # No icon for unknown AAGUID
+
+    assert model_admin.authenticator_name(credential) == "Unknown Authenticator"

--- a/tests/unit/contrib/identify/test_admin.py
+++ b/tests/unit/contrib/identify/test_admin.py
@@ -1,5 +1,6 @@
 import pytest
 from bs4 import BeautifulSoup
+from django.apps import apps
 from django.contrib.admin import AdminSite
 
 from django_otp_webauthn.admin import WebAuthnCredentialAdmin
@@ -23,6 +24,7 @@ class AdminWithMixins(
 @pytest.mark.django_db
 def test_webauthn_credential_modeladmin_mixins__apple(credential):
     """Verify that the admin mixins works correctly for Apple credentials."""
+    assert apps.is_installed("django_otp_webauthn.contrib.identify")
 
     credential.aaguid = APPLE_AAGUID
     credential.save()

--- a/tests/unit/contrib/identify/test_checks.py
+++ b/tests/unit/contrib/identify/test_checks.py
@@ -1,0 +1,59 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+
+
+def test_check_identify_passkey_package_installed(mocker, settings):
+    """Verify that a SystemCheckError is raised when the 'identify_passkey' package is not installed."""
+    assert "django_otp_webauthn.contrib.identify" in settings.INSTALLED_APPS
+
+    # Mock installed
+    mocker.patch(
+        "django_otp_webauthn.contrib.identify.utils.is_identify_passkey_package_installed",
+        return_value=False,
+    )
+
+    with pytest.raises(
+        SystemCheckError, match="The 'identify_passkey' package is not installed."
+    ):
+        call_command("check")
+
+    # Check that no error is raised when the package is installed
+    mocker.patch(
+        "django_otp_webauthn.contrib.identify.utils.is_identify_passkey_package_installed",
+        return_value=True,
+    )
+    call_command("check")
+
+
+def test_check_passkey_icon_finder_enabled(settings):
+    """Verify that a SystemCheckError is raised when the PasskeyIconsFinder is not enabled."""
+    assert "django_otp_webauthn.contrib.identify" in settings.INSTALLED_APPS
+
+    # Remove the PasskeyIconsFinder from STATICFILES_FINDERS
+    settings.STATICFILES_FINDERS = tuple(
+        finder
+        for finder in settings.STATICFILES_FINDERS
+        if finder != "django_otp_webauthn.contrib.identify.PasskeyIconsFinder"
+    )
+
+    with pytest.raises(
+        SystemCheckError,
+        match="Static file finder 'django_otp_webauthn.contrib.identify.PasskeyIconsFinder' is not enabled.",
+    ):
+        call_command("check")
+
+    # Add the PasskeyIconsFinder back to STATICFILES_FINDERS
+    settings.STATICFILES_FINDERS += (
+        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder",
+    )
+    call_command("check")
+
+    # Remove the PasskeyIconsFinder and add a subclass of it to STATICFILES_FINDERS
+    settings.STATICFILES_FINDERS = tuple(
+        finder
+        for finder in settings.STATICFILES_FINDERS
+        if finder != "django_otp_webauthn.contrib.identify.PasskeyIconsFinder"
+    )
+    settings.STATICFILES_FINDERS += ("tests.testapp.finders.CustomPasskeyIconsFinder",)
+    call_command("check")

--- a/tests/unit/contrib/identify/test_checks.py
+++ b/tests/unit/contrib/identify/test_checks.py
@@ -3,6 +3,24 @@ from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
 
+@pytest.mark.django_db
+def test_checks_noop_when_contrib_identify_not_installed(mocker, settings):
+    """Verify that the checks no-ops when the contrib.identify module is not installed, even if the check is registered."""
+    assert "django_otp_webauthn.contrib.identify" in settings.INSTALLED_APPS
+    mocker.patch(
+        "django_otp_webauthn.utils.is_contrib_identify_module_enabled",
+        return_value=False,
+    )
+
+    # Mock not installed, but still the check passes because the identify app is
+    # supposedly not installed (but checks are still registered)
+    mocker.patch(
+        "django_otp_webauthn.contrib.identify.utils.is_identify_passkey_package_installed",
+        return_value=False,
+    )
+    call_command("check")
+
+
 def test_check_identify_passkey_package_installed(mocker, settings):
     """Verify that a SystemCheckError is raised when the 'identify_passkey' package is not installed."""
     assert "django_otp_webauthn.contrib.identify" in settings.INSTALLED_APPS

--- a/tests/unit/contrib/identify/test_finders.py
+++ b/tests/unit/contrib/identify/test_finders.py
@@ -1,3 +1,4 @@
+import pytest
 from identify_passkey import PASSKEYS
 
 from django_otp_webauthn.contrib.identify import PasskeyIconsFinder
@@ -18,6 +19,8 @@ def test_passkeyiconfinder_can_find_static(settings, subtests):
     for _, (name, icon_light, icon_dark) in PASSKEYS.items():
         with subtests.test(msg=f"Icons for {name!r}"):
             for icon in (icon_light, icon_dark):
+                if icon is None:
+                    pytest.skip(f"No icon for {name!r}")
                 icon_path = f"django_otp_webauthn/passkey-icons/{icon}"
                 found = finder.find(icon_path)
                 assert found, f"Could not find static file for {name} at {icon_path}"

--- a/tests/unit/contrib/identify/test_finders.py
+++ b/tests/unit/contrib/identify/test_finders.py
@@ -1,0 +1,35 @@
+from identify_passkey import PASSKEYS
+
+from django_otp_webauthn.contrib.identify import PasskeyIconsFinder
+
+
+def test_passkeyiconfinder_can_find_static(settings, subtests):
+    """Verify that the PasskeyIconsFinder can find static files in the identify_passkey.icons package."""
+    assert any(
+        finder == "django_otp_webauthn.contrib.identify.PasskeyIconsFinder"
+        for finder in settings.STATICFILES_FINDERS
+    ), (
+        "django_otp_webauthn.contrib.identify.PasskeyIconsFinder is not in STATICFILES_FINDERS"
+    )
+
+    finder = PasskeyIconsFinder()
+
+    # Check that any passkey icon in the identify_passkey package can be found by PasskeyIconsFinder
+    for _, (name, icon_light, icon_dark) in PASSKEYS.items():
+        with subtests.test(msg=f"Icons for {name!r}"):
+            for icon in (icon_light, icon_dark):
+                icon_path = f"django_otp_webauthn/passkey-icons/{icon}"
+                found = finder.find(icon_path)
+                assert found, f"Could not find static file for {name} at {icon_path}"
+
+
+def test_passkeyiconfinder_noops_not_installed(mocker):
+    """If `identify_passkey` is not installed, the finder no-ops instead of failing loudly."""
+    mocker.patch(
+        "django_otp_webauthn.contrib.identify.utils.is_identify_passkey_package_installed",
+        return_value=False,
+    )
+    finder = PasskeyIconsFinder()
+    assert (
+        finder.find("django_otp_webauthn/passkey-icons/apple-passwords-icon.png") == []
+    )

--- a/tests/unit/contrib/identify/test_models.py
+++ b/tests/unit/contrib/identify/test_models.py
@@ -1,0 +1,91 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from django_otp_webauthn.contrib.identify import PasskeyDescriptor
+from django_otp_webauthn.utils import is_contrib_identify_module_enabled
+from tests.factories import (
+    WebAuthnCredentialFactory,
+)
+
+
+@pytest.mark.django_db
+def test_credential_identify():
+    """Verify that a WebAuthnCredential can be identified as a PasskeyDescriptor using the identify() method."""
+    credential_unknown = WebAuthnCredentialFactory(
+        aaguid="00000000-0000-0000-0000-000000000000"
+    )
+    credential_apple_passwords = WebAuthnCredentialFactory(
+        aaguid="fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+    )  # Apple Passwords
+
+    apple_descriptor = credential_apple_passwords.identify()
+
+    assert credential_unknown.identify() is None  # Not able to be identified
+    assert apple_descriptor is not None, (
+        "This credential should be identified as Apple Passwords, but it was not."
+    )
+    assert isinstance(apple_descriptor, PasskeyDescriptor)
+    assert apple_descriptor.name == "Apple Passwords"
+    assert apple_descriptor.aaguid == "fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+
+
+@pytest.mark.django_db
+def test_credential_inferred_name():
+    """Verify that a WebAuthnCredential has a populated inferred_name property when it can be identified."""
+    credential_unknown = WebAuthnCredentialFactory(
+        aaguid="00000000-0000-0000-0000-000000000000"
+    )
+    credential_apple_passwords = WebAuthnCredentialFactory(
+        aaguid="fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+    )  # Apple Passwords
+
+    assert credential_unknown.inferred_name is None  # Not able to be identified
+    assert credential_apple_passwords.inferred_name == "Apple Passwords"
+
+
+@pytest.mark.django_db
+def test_credential_str_representation():
+    """Verify that a WebAuthnCredential has a different default __str__ representation when it can be identified."""
+    credential_unknown = WebAuthnCredentialFactory(
+        name="", aaguid="00000000-0000-0000-0000-000000000000"
+    )
+    credential_apple_passwords = WebAuthnCredentialFactory(
+        name="", aaguid="fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+    )  # Apple Passwords
+
+    assert str(credential_unknown) == f" ({credential_unknown.user})"
+    assert (
+        str(credential_apple_passwords)
+        == f"Apple Passwords ({credential_apple_passwords.user})"
+    )
+
+    # But when we set the name explicitly, it should use that instead
+    credential_unknown.name = "My Custom Name"
+    assert str(credential_unknown) == f"My Custom Name ({credential_unknown.user})"
+    credential_apple_passwords.name = "My Custom Name"
+    assert (
+        str(credential_apple_passwords)
+        == f"My Custom Name ({credential_apple_passwords.user})"
+    )
+
+
+@pytest.mark.django_db
+def test_credential_identify__identify_app_not_installed(
+    settings,
+):
+    # Remove the identify app from INSTALLED_APPS to simulate it not being installed
+    settings.INSTALLED_APPS = [
+        app
+        for app in settings.INSTALLED_APPS
+        if app != "django_otp_webauthn.contrib.identify"
+    ]
+    assert not is_contrib_identify_module_enabled()
+
+    credential = WebAuthnCredentialFactory(
+        aaguid="fbfc3007-154e-4ecc-8c0b-6e020557d7bd"
+    )  # Apple Passwords
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="django_otp_webauthn.contrib.identify is not installed. Add it to your INSTALLED_APPS to use the identify feature.",
+    ):
+        credential.identify()

--- a/tests/unit/contrib/identify/test_models.py
+++ b/tests/unit/contrib/identify/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 
 from django_otp_webauthn.contrib.identify import PasskeyDescriptor
@@ -30,7 +31,7 @@ def test_credential_identify():
 
 
 @pytest.mark.django_db
-def test_credential_inferred_name():
+def test_credential_inferred_name(enable_contrib_identify_app):
     """Verify that a WebAuthnCredential has a populated inferred_name property when it can be identified."""
     credential_unknown = WebAuthnCredentialFactory(
         aaguid="00000000-0000-0000-0000-000000000000"
@@ -74,11 +75,13 @@ def test_credential_identify__identify_app_not_installed(
     settings,
 ):
     # Remove the identify app from INSTALLED_APPS to simulate it not being installed
-    settings.INSTALLED_APPS = [
-        app
-        for app in settings.INSTALLED_APPS
-        if app != "django_otp_webauthn.contrib.identify"
-    ]
+    apps.set_installed_apps(
+        [
+            app
+            for app in settings.INSTALLED_APPS
+            if app != "django_otp_webauthn.contrib.identify"
+        ]
+    )
     assert not is_contrib_identify_module_enabled()
 
     credential = WebAuthnCredentialFactory(
@@ -89,3 +92,5 @@ def test_credential_identify__identify_app_not_installed(
         match="django_otp_webauthn.contrib.identify is not installed. Add it to your INSTALLED_APPS to use the identify feature.",
     ):
         credential.identify()
+
+    apps.unset_installed_apps()  # Reset installed apps to original state

--- a/tests/unit/contrib/identify/test_types.py
+++ b/tests/unit/contrib/identify/test_types.py
@@ -1,0 +1,163 @@
+from typing import Literal
+
+import pytest
+from bs4 import BeautifulSoup
+from identify_passkey import PASSKEYS, identify_passkey
+
+from django_otp_webauthn.contrib.identify import (
+    identify_passkey as get_passkey_descriptor,
+)
+from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor, PasskeyIcon
+from tests.factories import APPLE_AAGUID
+
+
+def get_icon_descriptor(i, theme: Literal["light", "dark"] = "light"):
+    """Helper function to get the icon descriptor for a given passkey index and theme."""
+    passkey_descriptor = identify_passkey(list(PASSKEYS.items())[i][0])
+
+    if theme == "light":
+        return passkey_descriptor.icon_light
+    return passkey_descriptor.icon_dark
+
+
+def test_passkey_icon():
+    """Test that PasskeyIcon correctly wraps the identify_passkey.PasskeyIcon."""
+    icon = identify_passkey(APPLE_AAGUID).icon_light
+    passkey_icon = PasskeyIcon(ref=icon)
+
+    assert passkey_icon.mime_type == icon.mime_type
+    assert passkey_icon.data_uri == icon.data_uri
+    assert icon.path.name in passkey_icon.static_url
+    assert passkey_icon.data_uri == icon.data_uri
+    assert passkey_icon.static_url.endswith(icon.path.name)
+    assert passkey_icon.theme == "light"
+
+
+def test_passkey_descriptor():
+    """Test that PasskeyDescriptor correctly wraps the identify_passkey.PasskeyDescriptor."""
+    descriptor = identify_passkey(APPLE_AAGUID)
+    passkey_descriptor = PasskeyDescriptor(
+        aaguid=descriptor.aaguid,
+        name=descriptor.name,
+        icon_light=PasskeyIcon(ref=descriptor.icon_light)
+        if descriptor.icon_light
+        else None,
+        icon_dark=PasskeyIcon(ref=descriptor.icon_dark)
+        if descriptor.icon_dark
+        else None,
+    )
+
+    assert passkey_descriptor.aaguid == descriptor.aaguid
+    assert passkey_descriptor.name == descriptor.name
+    assert passkey_descriptor.has_icon
+
+    assert passkey_descriptor.icon_data_uri() == descriptor.icon_light.data_uri
+    assert passkey_descriptor.icon_data_uri("light") == descriptor.icon_light.data_uri
+    assert passkey_descriptor.icon_data_uri("dark") == descriptor.icon_dark.data_uri
+
+    # Light and dark icons are the same for Apple Passwords, so the data URIs should be the same
+    assert passkey_descriptor.icon_data_uri(
+        "light"
+    ) == passkey_descriptor.icon_data_uri("dark")
+
+    # Check the picture_html method works as expected. In this case, since light
+    # and dark are the same, this is optimized to not outputting any <source>
+    # tags, just a single <img> tag.
+    picture_html = BeautifulSoup(
+        passkey_descriptor.picture_html(picture_attrs={"class": "my-classname"}),
+        "html.parser",
+    )
+    assert picture_html.find("picture") is not None
+    assert picture_html.find("picture")["class"] == ["my-classname"]
+
+    assert picture_html.find("source") is None
+    assert picture_html.find("img")["src"] == passkey_descriptor.icon_light.static_url
+    assert picture_html.find("img")["width"] == "32"
+
+    # Replace the dark icon with a different one to test the <source> tag generation
+    passkey_descriptor = PasskeyDescriptor(
+        aaguid=descriptor.aaguid,
+        name=descriptor.name,
+        icon_light=PasskeyIcon(ref=descriptor.icon_light)
+        if descriptor.icon_light
+        else None,
+        icon_dark=PasskeyIcon(ref=get_icon_descriptor(0, theme="dark")),
+    )
+
+    # Request a width of 48 to test that the img_attrs parameter is respected
+    picture_html = BeautifulSoup(
+        passkey_descriptor.picture_html(img_attrs={"width": "48"}), "html.parser"
+    )
+    assert picture_html.find("picture") is not None
+    source_light = picture_html.find(
+        "source", {"media": "(prefers-color-scheme: light)"}
+    )
+    assert source_light is not None
+    assert source_light["srcset"] == passkey_descriptor.icon_light.static_url
+
+    source_dark = picture_html.find("source", {"media": "(prefers-color-scheme: dark)"})
+    assert source_dark is not None
+    assert source_dark["srcset"] == passkey_descriptor.icon_dark.static_url
+
+    img = picture_html.find("img")
+    assert img is not None
+    assert img["src"] == passkey_descriptor.icon_light.static_url
+    assert img["width"] == "48"
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_passkey_descriptor_picture_html_with_only_one_icon(theme):
+    """Test that PasskeyDescriptor.picture_html() correctly handles cases where only one icon is provided."""
+    # Request with only a light icon to test that no <source> tag is generated for dark mode
+    descriptor = identify_passkey(APPLE_AAGUID)
+    passkey_descriptor = PasskeyDescriptor(
+        aaguid=descriptor.aaguid,
+        name=descriptor.name,
+        icon_light=PasskeyIcon(ref=descriptor.icon_light) if theme == "light" else None,
+        icon_dark=PasskeyIcon(ref=descriptor.icon_dark) if theme == "dark" else None,
+    )
+    picture_html = BeautifulSoup(passkey_descriptor.picture_html(), "html.parser")
+    assert picture_html.find("picture") is not None
+    assert picture_html.find("source") is not None
+    assert picture_html.find("source")["media"] == (
+        "(prefers-color-scheme: light)"
+        if theme == "light"
+        else "(prefers-color-scheme: dark)"
+    )
+    assert picture_html.find("img")["src"] == (
+        passkey_descriptor.icon_light.static_url
+        if theme == "light"
+        else passkey_descriptor.icon_dark.static_url
+    )
+
+
+def test_passkey_descriptor_icon_data_uri__raise_invalid_theme():
+    """Test that PasskeyDescriptor raises a ValueError for an invalid theme."""
+    passkey_descriptor = get_passkey_descriptor(APPLE_AAGUID)
+
+    with pytest.raises(
+        ValueError, match="Invalid theme: invalid_theme. Must be 'light' or 'dark'."
+    ):
+        passkey_descriptor.icon_data_uri("invalid_theme")
+
+
+def test_passkey_descriptor_no_icons():
+    """Test that PasskeyDescriptor correctly handles a passkey with no icons."""
+    # Use a passkey that has no icons. For this test, we'll use the first passkey in the list.
+    passkey_descriptor = get_passkey_descriptor(APPLE_AAGUID)
+    pk = PasskeyDescriptor(
+        aaguid=passkey_descriptor.aaguid,
+        name=passkey_descriptor.name,
+        icon_light=None,
+        icon_dark=None,
+    )
+
+    assert not pk.has_icon
+
+    # The picture_html method should return an empty string since there are no icons
+    picture_html = pk.picture_html()
+    assert picture_html == ""
+
+    assert pk.icon_data_uri() is None
+    assert pk.icon_data_uri("light") is None
+    assert pk.icon_data_uri("dark") is None

--- a/tests/unit/contrib/identify/test_types.py
+++ b/tests/unit/contrib/identify/test_types.py
@@ -8,6 +8,7 @@ from django_otp_webauthn.contrib.identify import (
     identify_passkey as get_passkey_descriptor,
 )
 from django_otp_webauthn.contrib.identify.types import PasskeyDescriptor, PasskeyIcon
+from django_otp_webauthn.utils import is_contrib_identify_module_enabled
 from tests.factories import APPLE_AAGUID
 
 
@@ -35,6 +36,7 @@ def test_passkey_icon():
 
 def test_passkey_descriptor():
     """Test that PasskeyDescriptor correctly wraps the identify_passkey.PasskeyDescriptor."""
+    assert is_contrib_identify_module_enabled()
     descriptor = identify_passkey(APPLE_AAGUID)
     passkey_descriptor = PasskeyDescriptor(
         aaguid=descriptor.aaguid,
@@ -108,6 +110,7 @@ def test_passkey_descriptor():
 @pytest.mark.parametrize("theme", ["light", "dark"])
 def test_passkey_descriptor_picture_html_with_only_one_icon(theme):
     """Test that PasskeyDescriptor.picture_html() correctly handles cases where only one icon is provided."""
+    assert is_contrib_identify_module_enabled()
     # Request with only a light icon to test that no <source> tag is generated for dark mode
     descriptor = identify_passkey(APPLE_AAGUID)
     passkey_descriptor = PasskeyDescriptor(

--- a/tests/unit/contrib/identify/test_utils.py
+++ b/tests/unit/contrib/identify/test_utils.py
@@ -1,0 +1,8 @@
+from django_otp_webauthn.contrib.identify import utils
+
+
+def test_is_identify_passkey_package_installed__module_not_found(mocker):
+    """Verify that is_identify_passkey_package_installed returns False when the identify_passkey package is not installed."""
+    mocker.patch("importlib.util.find_spec", side_effect=ModuleNotFoundError)
+
+    assert not utils.is_identify_passkey_package_installed()

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -13,7 +13,6 @@ def test_check_settings_relying_party_id__not_set(settings):
     """Verify that a SystemCheckError is raised when the relying party ID is not set."""
     settings.OTP_WEBAUTHN_RP_ID_CALLABLE = None
     settings.OTP_WEBAUTHN_RP_ID = None
-
     with pytest.raises(SystemCheckError, match="Relying party ID not configured"):
         call_command("check")
 
@@ -202,4 +201,29 @@ def test_check_settings_dangerous_session_backend_used(settings):
     call_command("check")
 
     settings.SESSION_ENGINE = "django.contrib.sessions.backends.db"
+    call_command("check")
+
+
+@pytest.mark.django_db
+def test_check_settings_attestation_conveyance_preference(settings):
+    """Verify that a SystemCheckError is raised when the attestation conveyance preference is invalid."""
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "invalid_value"
+
+    with pytest.raises(
+        SystemCheckError,
+        match="Invalid attestation conveyance preference",
+    ):
+        call_command("check")
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "none"
+    call_command("check")
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "indirect"
+    call_command("check")
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "direct"
+    call_command("check")
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "enterprise"
     call_command("check")

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -97,10 +97,19 @@ def test_helper_get_discoverable_credentials_preference(helper, settings):
     )
 
 
-def test_helper_get_attestation_conveyance_preference(helper):
+def test_helper_get_attestation_conveyance_preference(helper, settings):
+    del (
+        settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE
+    )  # Explicitly unset the setting to test the default value
     assert (
         helper.get_attestation_conveyance_preference()
-        == AttestationConveyancePreference.NONE
+        == AttestationConveyancePreference.NONE  # Default value
+    )
+
+    settings.OTP_WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE = "direct"
+    assert (
+        helper.get_attestation_conveyance_preference()
+        == AttestationConveyancePreference.DIRECT
     )
 
 


### PR DESCRIPTION
Optional module for identifying passkey manufacturer, intended to compliment a user interface with a fallback name and an appropriate passkey icon.