### PR TITLE
Remove admonition from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
 
 This package provides an implementation of [WebAuthn Passkeys](https://passkeys.dev/) for Django. It is written as a plugin for the [Django OTP framework](https://github.com/django-otp/django-otp) for multi-factor authentication. Under the hood, this package uses [py_webauth](https://github.com/duo-labs/py_webauthn/) to handle all cryptographic operations.
 
-> [!IMPORTANT]
-> As of May 2025, I now consider this package stable enough for production use. It is still fairly new though, so you may encounter bugs or issues. If you do, please let me know!
-
 - [Django OTP WebAuthn](#django-otp-webauthn)
   - [Compatibility](#compatibility)
     - [Browser compatibility](#browser-compatibility)


### PR DESCRIPTION
Its been long enough and no one has come forward with mind boggling bugs. I've not had any issues running this myself so the additional caution sign is not necessary anymore.